### PR TITLE
Adding missing README from svn to fix make install breakage

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,55 @@
+
+	  distcc -- a free distributed C/C++ compiler system
+
+		   http://code.google.com/p/distcc/
+
+		    by Martin Pool <mbp@samba.org>
+
+		    "pump" functionality added by
+ Fergus Henderson, Nils Klarlund, Manos Renieris, and Craig Silverstein
+			    (Google Inc.)
+
+distcc is a program to distribute compilation of C or C++ code across
+several machines on a network. distcc should always generate the same
+results as a local compile, is simple to install and use, and is often
+two or more times faster than a local compile.
+
+Unlike other distributed build systems, distcc does not require all
+machines to share a filesystem, have synchronized clocks, or to have
+the same libraries or header files installed. Machines can be running
+different operating systems, as long as they have compatible binary
+formats or cross-compilers.
+
+By default, distcc sends the complete preprocessed source code across
+the network for each job, so all it requires of the volunteer machines
+is that they be running the distccd daemon, and that they have an
+appropriate compiler installed.
+
+The distcc "pump" functionality, added in distcc 3.0, improves on
+distcc by distributing not only compilation but also preprocessing to
+distcc servers. This requires that the server and client have the same
+system headers (the client takes responsibility for transmitting
+application-specific headers).  Given that, distcc in pump mode yields
+the same results that distcc would in non-pump mode, but faster, since
+the preprocessor no longer runs locally. For more details on the pump
+functionality, see README.pump.
+
+distcc is not itself a compiler, but rather a front-end to the GNU
+C/C++ compiler (gcc), or another compiler of your choice. All the
+regular gcc options and features work as normal.
+
+distcc is designed to be used with GNU make's parallel-build feature
+(-j). Shipping files across the network takes time, but few cycles on
+the client machine. Any files that can be built remotely are
+essentially "for free" in terms of client CPU.  This is even more true
+in "pump" mode, where the client does not even have to take time to
+preprocess the source files.  distcc has been successfully used in
+environments with hundreds of distcc servers, supporting dozens of
+simultaneous compiles.
+
+distcc is now reasonably stable and can successfully compile the Linux
+kernel, rsync, KDE, GNOME (via GARNOME), Samba and Ethereal.  distcc
+is nearly linearly scalable for small numbers of machines: for a
+typical case, three machines are 2.6 times faster than one.
+
+distcc is distributed under the GNU General Public Licence v2.


### PR DESCRIPTION
Hello,

During `make install` the target `install_doc` complains about README missing, I looked around the issues and did not find something reported for this. The way I fixed it for now is by copying the README from the original svn repo: `https://distcc.googlecode.com/svn/trunk/README`. Let me know if that is ok with you?

Cheers

Amine