### PR TITLE
Avoid protocol derailment for errors

### DIFF
--- a/src/serve.c
+++ b/src/serve.c
@@ -689,13 +689,16 @@ static int dcc_run_job(int in_fd,
     if ((ret = dcc_x_result_header(out_fd, protover))
         || (ret = dcc_x_cc_status(out_fd, status))
         || (ret = dcc_x_file(out_fd, err_fname, "SERR", compr, NULL))
-        || (ret = dcc_x_file(out_fd, out_fname, "SOUT", compr, NULL))
-        || WIFSIGNALED(status)
-        || WEXITSTATUS(status)) {
+        || (ret = dcc_x_file(out_fd, out_fname, "SOUT", compr, NULL))) {
+          /* We get a protocol derailment if we send DOTO 0 here */
+
+        if (job_result == -1)
+            job_result = STATS_COMPILE_ERROR;
+    } else if (WIFSIGNALED(status) || WEXITSTATUS(status)) {
         /* Something went wrong, so send DOTO 0 */
         dcc_x_token_int(out_fd, "DOTO", 0);
 
-    if (job_result == -1)
+        if (job_result == -1)
             job_result = STATS_COMPILE_ERROR;
     } else {
         if (cpp_where == DCC_CPP_ON_SERVER) {


### PR DESCRIPTION
Sometimes on a busy server, you will get errors reading stdout/stderr.
If we send out DOTO 0 without SERR/SOUT, we get a protocol derailment.

It is better to avoid sending DOTO 0 in those cases, so that we get a
better error report on the client and avoid a "scary" warning message.
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
  *
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
