### PR TITLE
Localslots with gcc -E

### DIFF
--- a/man/distcc.1
+++ b/man/distcc.1
@@ -728,6 +728,9 @@ Timeout.
 .TP
 119
 GSS-API - Catchall error code for GSS-API related errors.
+.TP
+120
+Called for preprocessing, which needs to be done locally.
 
 .SH "FILES"
 If $DISTCC_HOSTS is not set, distcc reads a host list from either 

--- a/man/distcc.1
+++ b/man/distcc.1
@@ -77,12 +77,12 @@ For example, concurrent linking should be severely curtailed using auxiliary
 locks.  The effect of other build activity, such as Java compilation when
 building mixed code, should be considered.  The
 .B --localslots_cpp
-parameter is by default set to 16.
+parameter is by default set to 8.
 This limits the number of concurrent processes that do preprocessing in 
 plain distcc (non-pump) mode.
 Therefore, larger 
 .B -j 
-values than 16 may be used without overloading a single-CPU
+values than 8 may be used without overloading a single-CPU
 client due to preprocessing.  Such large values may speed up parts of the build
 that do not involve C compilations, but they may not be useful to distcc
 efficiency in plain mode.

--- a/src/arg.c
+++ b/src/arg.c
@@ -158,7 +158,7 @@ int dcc_scan_args(char *argv[], char **input_file, char **output_file,
         if (a[0] == '-') {
             if (!strcmp(a, "-E")) {
                 rs_trace("-E call for cpp must be local");
-                return EXIT_DISTCC_FAILED;
+                return EXIT_LOCAL_CPP;
             } else if (!strcmp(a, "-MD") || !strcmp(a, "-MMD")) {
                 /* These two generate dependencies as a side effect.  They
                  * should work with the way we call cpp. */

--- a/src/compile.c
+++ b/src/compile.c
@@ -748,7 +748,11 @@ dcc_build_somewhere(char *argv[],
 
   lock_local:
     dcc_read_localslots_configuration();
-    dcc_lock_local(&cpu_lock_fd);
+    if (ret == EXIT_LOCAL_CPP) {
+        dcc_lock_local_cpp(&local_cpu_lock_fd);
+    } else {
+        dcc_lock_local(&cpu_lock_fd);
+    }
 
   run_local:
     /* Either compile locally, after remote failure, or simply do other cc tasks

--- a/src/compile.c
+++ b/src/compile.c
@@ -747,6 +747,7 @@ dcc_build_somewhere(char *argv[],
     }
 
   lock_local:
+    dcc_read_localslots_configuration();
     dcc_lock_local(&cpu_lock_fd);
 
   run_local:

--- a/src/exitcode.h
+++ b/src/exitcode.h
@@ -59,12 +59,11 @@ enum dcc_exitcode {
     EXIT_NO_SUCH_FILE             = 115,
     EXIT_NO_HOSTS                 = 116,
     EXIT_GONE                     = 117, /**< No longer relevant */
-#ifdef HAVE_GSSAPI
     EXIT_TIMEOUT                  = 118,
-    EXIT_GSSAPI_FAILED            = 119 /**< GSS-API - Catchall error code for GSS-API related errors. */
-#else
-    EXIT_TIMEOUT                  = 118
+#ifdef HAVE_GSSAPI
+    EXIT_GSSAPI_FAILED            = 119, /**< GSS-API - Catchall error code for GSS-API related errors. */
 #endif
+    EXIT_LOCAL_CPP                = 120
 };
 
 

--- a/src/where.c
+++ b/src/where.c
@@ -83,6 +83,22 @@ static int dcc_lock_one(struct dcc_hostdef *hostlist,
                         int *cpu_lock_fd);
 
 
+void dcc_read_localslots_configuration()
+{
+    struct dcc_hostdef *hostlist;
+    int ret;
+    int n_hosts;
+
+    if ((ret = dcc_get_hostlist(&hostlist, &n_hosts)) == 0) {
+        while (hostlist) {
+            struct dcc_hostdef *l = hostlist;
+            hostlist = hostlist->next;
+            dcc_free_hostdef(l);
+        }
+    }
+}
+
+
 int dcc_pick_host_from_list_and_lock_it(struct dcc_hostdef **buildhost,
                             int *cpu_lock_fd)
 {

--- a/src/where.h
+++ b/src/where.h
@@ -22,6 +22,7 @@
  */
 
 /* where.c */
+void dcc_read_localslots_configuration(void);
 int dcc_pick_host_from_list_and_lock_it(struct dcc_hostdef **,
                                         int *cpu_lock_fd);
 


### PR DESCRIPTION
Currently the --localslots are only read when distributing,
not when running locally.  Make sure to always parse the hosts
configuration, for localslots. We want to use --localslots_cpp
for running gcc -E, so use a special exit code to signal this.
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
  *
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
