### PR TITLE
Add help for systemd-based RH-like distro users

### DIFF
--- a/packaging/RedHat/conf/clients.allow
+++ b/packaging/RedHat/conf/clients.allow
@@ -21,5 +21,9 @@
 # (apart from comments) and thus only allow SSH mode rather than TCP mode.
 # However, be aware that SSH mode has poorer performance than TCP mode.
 
+# For RedHat-like distributions using systemd, you should instead look in:
+# /etc/sysconfig/distccd in order to configure the trusted hosts list
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1187517
+
 # Add your trusted hosts here, e.g. start by uncommented the line below.
 # 127.0.0.1


### PR DESCRIPTION
Recent RedHat-like distributions run distcc through systemd and
the configuration is not taken from this file, so add a comment that
put the poor user in the right direction.

This patch is RFC here because the downstream bug has not been
fixed and is going to be EOL'ed

See: https://bugzilla.redhat.com/show_bug.cgi?id=1187517

If this is not the way it should be fixed^Wworkarounded, please advise...