### PR TITLE
Handle 64-bit time_t on OpenBSD

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -819,8 +819,8 @@ int dcc_build_somewhere_timed(char *argv[],
         timeval_subtract(&delta, &after, &before);
 
         rs_log(RS_LOG_INFO|RS_LOG_NONAME,
-               "elapsed compilation time %ld.%06lds",
-               delta.tv_sec, (long) delta.tv_usec);
+               "elapsed compilation time %lld.%06lds",
+               (long long) delta.tv_sec, (long) delta.tv_usec);
     }
 
     return ret;

--- a/src/exec.c
+++ b/src/exec.c
@@ -489,11 +489,11 @@ int dcc_collect_child(const char *what, pid_t pid,
              * critique_status(). */
             rs_trace("%s child %ld terminated with status %#x",
                      what, (long) ret_pid, *wait_status);
-            rs_log_info("%s times: user %ld.%06lds, system %ld.%06lds, "
+            rs_log_info("%s times: user %lld.%06lds, system %lld.%06lds, "
                         "%ld minflt, %ld majflt",
                         what,
-                        ru.ru_utime.tv_sec, (long) ru.ru_utime.tv_usec,
-                        ru.ru_stime.tv_sec, (long) ru.ru_stime.tv_usec,
+                        (long long) ru.ru_utime.tv_sec, (long) ru.ru_utime.tv_usec,
+                        (long long) ru.ru_stime.tv_sec, (long) ru.ru_stime.tv_usec,
                         ru.ru_minflt, ru.ru_majflt);
 
             return 0;

--- a/src/lsdistcc.c
+++ b/src/lsdistcc.c
@@ -479,8 +479,8 @@ void server_handle_event(state_t *sp)
 
         if (opt_verbose > 2)
             fprintf(stderr,
-                    "now %ld %ld: server_handle_event: %s: state %d\n",
-                    now.tv_sec, (long) now.tv_usec/1000,
+                    "now %lld %ld: server_handle_event: %s: state %d\n",
+                    (long long) now.tv_sec, (long) now.tv_usec/1000,
                     sp->req.hname, sp->status);
 
         switch (sp->status) {
@@ -506,8 +506,9 @@ void server_handle_event(state_t *sp)
                 /* start the nonblocking connect... */
                 if (opt_verbose > 0)
                     fprintf(stderr,
-                            "now %ld %ld: Connecting to %s\n",
-                            now.tv_sec, (long) now.tv_usec/1000, sp->req.hname);
+                            "now %lld %ld: Connecting to %s\n",
+                            (long long) now.tv_sec, (long) now.tv_usec/1000,
+                            sp->req.hname);
                 if (connect(sp->fd, (struct sockaddr *)&sa, sizeof(sa))
                     && errno != EINPROGRESS) {
                     if (opt_verbose > 0)
@@ -542,10 +543,10 @@ void server_handle_event(state_t *sp)
                 if (connecterr) {
                     if (opt_verbose > 0)
                        fprintf(stderr,
-                               "now %ld %ld: Connecting to %s failed "
+                               "now %lld %ld: Connecting to %s failed "
                                "with errno %d = %s\n",
-                         now.tv_sec, (long) now.tv_usec/1000, sp->req.hname,
-                         connecterr, strerror(connecterr));
+                         (long long) now.tv_sec, (long) now.tv_usec/1000,
+                         sp->req.hname, connecterr, strerror(connecterr));
                     sp->status = STATE_CLOSE;   /* not listening */
                     break;
                 }
@@ -557,23 +558,24 @@ void server_handle_event(state_t *sp)
                 }
                 if (opt_verbose > 0)
                     fprintf(stderr,
-                            "now %ld %ld: %s: sending compile request\n",
-                            now.tv_sec, (long) now.tv_usec/1000, sp->req.hname);
+                            "now %lld %ld: %s: sending compile request\n",
+                            (long long) now.tv_sec, (long) now.tv_usec/1000,
+                            sp->req.hname);
                 nsend = canned_query_len;
                 nsent = write(sp->fd, canned_query, nsend);
                 if (nsent != nsend) {
                     if (opt_verbose > 1) {
                         if (nsent == -1)
                             fprintf(stderr,
-                                    "now %ld %ld: Sending to %s failed, "
+                                    "now %lld %ld: Sending to %s failed, "
                                     "errno %d\n",
-                                    now.tv_sec, (long) now.tv_usec/1000, sp->req.hname,
-                                    connecterr);
+                                    (long long) now.tv_sec, (long) now.tv_usec/1000,
+                                    sp->req.hname, connecterr);
                         else
                             fprintf(stderr,
-                                    "now %ld %ld: Sending to %s failed, "
+                                    "now %lld %ld: Sending to %s failed, "
                                     "nsent %d != nsend %d\n",
-                                    now.tv_sec, (long) now.tv_usec/1000,
+                                    (long long) now.tv_sec, (long) now.tv_usec/1000,
                                     sp->req.hname, nsent, nsend);
                     }
                     /* ??? remote disconnect?  Buffer too small? */
@@ -743,10 +745,11 @@ static int one_poll_loop(struct rslave_s* rs, struct state_s states[],
             nwithtries[sp->ntries]++;
             if (opt_verbose > 0)
                 fprintf(stderr,
-                        "now %ld %ld: Resending %s because "
-                        "deadline was %ld %ld\n",
-                        now.tv_sec, (long) now.tv_usec/1000, sp->req.hname,
-                        sp->deadline.tv_sec, (long) sp->deadline.tv_usec/1000);
+                        "now %lld %ld: Resending %s because "
+                        "deadline was %lld %ld\n",
+                        (long long) now.tv_sec, (long) now.tv_usec/1000,
+                        sp->req.hname, sp->deadline.tv_sec,
+                        (long) sp->deadline.tv_usec/1000);
             break;
         }
 
@@ -758,8 +761,9 @@ static int one_poll_loop(struct rslave_s* rs, struct state_s states[],
             server_handle_event(sp);
             if (opt_verbose > 0)
                 fprintf(stderr,
-                        "now %ld %ld: %s timed out while connecting\n",
-                        now.tv_sec, (long) now.tv_usec/1000, sp->req.hname);
+                        "now %lld %ld: %s timed out while connecting\n",
+                        (long long) now.tv_sec, (long) now.tv_usec/1000,
+                        sp->req.hname);
         }
         if ((sp->status == STATE_READ_DONEPKT ||
              sp->status == STATE_READ_STATPKT ||
@@ -771,8 +775,9 @@ static int one_poll_loop(struct rslave_s* rs, struct state_s states[],
             server_handle_event(sp);
             if (opt_verbose > 0)
                 fprintf(stderr,
-                        "now %ld %ld: %s timed out while compiling\n",
-                        now.tv_sec, (long) now.tv_usec/1000, sp->req.hname);
+                        "now %lld %ld: %s timed out while compiling\n",
+                        (long long) now.tv_sec, (long) now.tv_usec/1000,
+                        sp->req.hname);
         }
     }
     if (!found && (nwithtries[1] <= overlap) &&
@@ -793,8 +798,9 @@ static int one_poll_loop(struct rslave_s* rs, struct state_s states[],
        and mark its timeout. */
     if (found) {
         if (opt_verbose)
-            fprintf(stderr, "now %ld %ld: Looking up %s\n",
-                    now.tv_sec, (long) now.tv_usec/1000, sp->req.hname);
+            fprintf(stderr, "now %lld %ld: Looking up %s\n",
+                    (long long) now.tv_sec, (long) now.tv_usec/1000,
+		    sp->req.hname);
         rslave_writeRequest(rs, &sp->req);
         sp->deadline = now;
         sp->deadline.tv_usec += dnstimeout_usec;
@@ -831,8 +837,8 @@ static int one_poll_loop(struct rslave_s* rs, struct state_s states[],
 
                 if (result.err) {
                     if (opt_verbose)
-                        fprintf(stderr, "now %ld %ld: %s not found\n",
-                                now.tv_sec, (long) now.tv_usec/1000,
+                        fprintf(stderr, "now %lld %ld: %s not found\n",
+                                (long long) now.tv_sec, (long) now.tv_usec/1000,
                                 sp->req.hname);
                     sp->status = STATE_DONE;
                     ndone++;


### PR DESCRIPTION
On OpenBSD, time_t is defined as a 64-bit type. So adjust the format string accordingly and make sure this gets casted correctly for other systems too.
