### PR TITLE
Avoid locking the CPU for preprocessed input

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -560,10 +560,12 @@ dcc_build_somewhere(char *argv[],
         goto run_local;
     }
 
-    /* Lock the local CPU, since we're going to be doing preprocessing
-     * or include scanning. */
-    if ((ret = dcc_lock_local_cpp(&local_cpu_lock_fd)) != 0) {
-        goto fallback;
+    if (!dcc_is_preprocessed(input_fname)) {
+        /* Lock the local CPU, since we're going to be doing preprocessing
+         * or include scanning. */
+        if ((ret = dcc_lock_local_cpp(&local_cpu_lock_fd)) != 0) {
+            goto fallback;
+        }
     }
 
     if (host->cpp_where == DCC_CPP_ON_SERVER) {


### PR DESCRIPTION
It is not needed to (possibly having to first wait for and then) take a
lock on localslots_cpp for preprocessed input (such as emitted by ccache).

We are not going to start the preprocessor, and will not try to preprocess
remotely with pump. So the preprocessor lock taken will be unnecessary anyway.
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
  *
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
