### PR TITLE
Add UNUSED macro to make CC happy with -Werror option.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1030,7 +1030,7 @@ showpaths:
 # tricky features so mkinstalldirs and cp will do
 
 install: showpaths install-doc install-man install-programs \
-	install-include-server install-example @INSTALL_GNOME@ install-conf
+	install-include-server install-example @INSTALL_GNOME@
 
 install-programs: $(bin_PROGRAMS)
 	$(mkinstalldirs) "$(DESTDIR)$(bindir)"
@@ -1069,7 +1069,7 @@ install-include-server: include-server pump
 	        --build-base="$(include_server_builddir)" \
 	        --build-temp="$(include_server_builddir)" \
 	      install 					\
-	         --prefix="$(prefix)" 			\
+	         --install-lib="$(prefix)/lib/distcc-pump" \
 	         --record="$(include_server_builddir)/install.log.pre" \
 	         --root="$$DESTDIR"                     \
 	    || exit 1; \
@@ -1081,7 +1081,7 @@ install-include-server: include-server pump
 	    cp -f "$(include_server_builddir)/install.log" "$(PYTHON_INSTALL_RECORD)"; \
 	  fi; \
 	  $(mkinstalldirs) "$(DESTDIR)$(bindir)" && \
-	  INCLUDE_SERVER=`grep '/include_server.py$$' "$(include_server_builddir)/install.log"` && \
+	  INCLUDE_SERVER="/usr/lib/distcc-pump/include_server/include_server.py" && \
 	  sed "s,^include_server='',include_server='$$INCLUDE_SERVER'," \
 	    pump > "$(include_server_builddir)/pump" && \
 	  $(INSTALL_PROGRAM) "$(include_server_builddir)/pump" "$(DESTDIR)$(bindir)"; \

--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,8 @@ AC_PROG_INSTALL
 #
 # NB: Cannot use AC_CONFIG_LIBOBJ_DIR here, because it's not present
 # in autoconf 2.53.
-AM_PATH_PYTHON([3.1],,[:])
+AM_PATH_PYTHON([3.1])
+AX_PYTHON_DEVEL([>= '3.1'])
 AC_ARG_VAR(PYTHON, [Python interpreter])
 AC_SUBST(PYTHON_RELATIVE_LIB)
 AC_C_INLINE

--- a/m4/ax_python_devel.m4
+++ b/m4/ax_python_devel.m4
@@ -1,0 +1,327 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_python_devel.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PYTHON_DEVEL([version])
+#
+# DESCRIPTION
+#
+#   Note: Defines as a precious variable "PYTHON_VERSION". Don't override it
+#   in your configure.ac.
+#
+#   This macro checks for Python and tries to get the include path to
+#   'Python.h'. It provides the $(PYTHON_CPPFLAGS) and $(PYTHON_LIBS) output
+#   variables. It also exports $(PYTHON_EXTRA_LIBS) and
+#   $(PYTHON_EXTRA_LDFLAGS) for embedding Python in your code.
+#
+#   You can search for some particular version of Python by passing a
+#   parameter to this macro, for example ">= '2.3.1'", or "== '2.4'". Please
+#   note that you *have* to pass also an operator along with the version to
+#   match, and pay special attention to the single quotes surrounding the
+#   version number. Don't use "PYTHON_VERSION" for this: that environment
+#   variable is declared as precious and thus reserved for the end-user.
+#
+#   This macro should work for all versions of Python >= 2.1.0. As an end
+#   user, you can disable the check for the python version by setting the
+#   PYTHON_NOVERSIONCHECK environment variable to something else than the
+#   empty string.
+#
+#   If you need to use this macro for an older Python version, please
+#   contact the authors. We're always open for feedback.
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Sebastian Huber <sebastian-huber@web.de>
+#   Copyright (c) 2009 Alan W. Irwin
+#   Copyright (c) 2009 Rafael Laboissiere <rafael@laboissiere.net>
+#   Copyright (c) 2009 Andrew Collier
+#   Copyright (c) 2009 Matteo Settenvini <matteo@member.fsf.org>
+#   Copyright (c) 2009 Horst Knorr <hk_classes@knoda.org>
+#   Copyright (c) 2013 Daniel Mullner <muellner@math.stanford.edu>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 18
+
+AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
+AC_DEFUN([AX_PYTHON_DEVEL],[
+	#
+	# Allow the use of a (user set) custom python version
+	#
+	AC_ARG_VAR([PYTHON_VERSION],[The installed Python
+		version to use, for example '2.3'. This string
+		will be appended to the Python interpreter
+		canonical name.])
+
+	AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
+	if test -z "$PYTHON"; then
+	   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
+	   PYTHON_VERSION=""
+	fi
+
+	#
+	# Check for a version of Python >= 2.1.0
+	#
+	AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
+	ac_supports_python_ver=`$PYTHON -c "import sys; \
+		ver = sys.version.split ()[[0]]; \
+		print (ver >= '2.1.0')"`
+	if test "$ac_supports_python_ver" != "True"; then
+		if test -z "$PYTHON_NOVERSIONCHECK"; then
+			AC_MSG_RESULT([no])
+			AC_MSG_FAILURE([
+This version of the AC@&t@_PYTHON_DEVEL macro
+doesn't work properly with versions of Python before
+2.1.0. You may need to re-run configure, setting the
+variables PYTHON_CPPFLAGS, PYTHON_LIBS, PYTHON_SITE_PKG,
+PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS by hand.
+Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
+to something else than an empty string.
+])
+		else
+			AC_MSG_RESULT([skip at user request])
+		fi
+	else
+		AC_MSG_RESULT([yes])
+	fi
+
+	#
+	# if the macro parameter ``version'' is set, honour it
+	#
+	if test -n "$1"; then
+		AC_MSG_CHECKING([for a version of Python $1])
+		ac_supports_python_ver=`$PYTHON -c "import sys; \
+			ver = sys.version.split ()[[0]]; \
+			print (ver $1)"`
+		if test "$ac_supports_python_ver" = "True"; then
+		   AC_MSG_RESULT([yes])
+		else
+			AC_MSG_RESULT([no])
+			AC_MSG_ERROR([this package requires Python $1.
+If you have it installed, but it isn't the default Python
+interpreter in your system path, please pass the PYTHON_VERSION
+variable to configure. See ``configure --help'' for reference.
+])
+			PYTHON_VERSION=""
+		fi
+	fi
+
+	#
+	# Check if you have distutils, else fail
+	#
+	AC_MSG_CHECKING([for the distutils Python package])
+	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
+	if test -z "$ac_distutils_result"; then
+		AC_MSG_RESULT([yes])
+	else
+		AC_MSG_RESULT([no])
+		AC_MSG_ERROR([cannot import Python module "distutils".
+Please check your Python installation. The error was:
+$ac_distutils_result])
+		PYTHON_VERSION=""
+	fi
+
+	#
+	# Check for Python include path
+	#
+	AC_MSG_CHECKING([for Python include path])
+	if test -z "$PYTHON_CPPFLAGS"; then
+		python_path=`$PYTHON -c "import distutils.sysconfig; \
+			print (distutils.sysconfig.get_python_inc ());"`
+		plat_python_path=`$PYTHON -c "import distutils.sysconfig; \
+			print (distutils.sysconfig.get_python_inc (plat_specific=1));"`
+		if test -n "${python_path}"; then
+			if test "${plat_python_path}" != "${python_path}"; then
+				python_path="-I$python_path -I$plat_python_path"
+			else
+				python_path="-I$python_path"
+			fi
+		fi
+		PYTHON_CPPFLAGS=$python_path
+	fi
+	AC_MSG_RESULT([$PYTHON_CPPFLAGS])
+	AC_SUBST([PYTHON_CPPFLAGS])
+
+	#
+	# Check for Python library path
+	#
+	AC_MSG_CHECKING([for Python library path])
+	if test -z "$PYTHON_LIBS"; then
+		# (makes two attempts to ensure we've got a version number
+		# from the interpreter)
+		ac_python_version=`cat<<EOD | $PYTHON -
+
+# join all versioning strings, on some systems
+# major/minor numbers could be in different list elements
+from distutils.sysconfig import *
+e = get_config_var('VERSION')
+if e is not None:
+	print(e)
+EOD`
+
+		if test -z "$ac_python_version"; then
+			if test -n "$PYTHON_VERSION"; then
+				ac_python_version=$PYTHON_VERSION
+			else
+				ac_python_version=`$PYTHON -c "import sys; \
+					print (sys.version[[:3]])"`
+			fi
+		fi
+
+		# Make the versioning information available to the compiler
+		AC_DEFINE_UNQUOTED([HAVE_PYTHON], ["$ac_python_version"],
+                                   [If available, contains the Python version number currently in use.])
+
+		# First, the library directory:
+		ac_python_libdir=`cat<<EOD | $PYTHON -
+
+# There should be only one
+import distutils.sysconfig
+e = distutils.sysconfig.get_config_var('LIBDIR')
+if e is not None:
+	print (e)
+EOD`
+
+		# Now, for the library:
+		ac_python_library=`cat<<EOD | $PYTHON -
+
+import distutils.sysconfig
+c = distutils.sysconfig.get_config_vars()
+if 'LDVERSION' in c:
+	print ('python'+c[['LDVERSION']])
+else:
+	print ('python'+c[['VERSION']])
+EOD`
+
+		# This small piece shamelessly adapted from PostgreSQL python macro;
+		# credits goes to momjian, I think. I'd like to put the right name
+		# in the credits, if someone can point me in the right direction... ?
+		#
+		if test -n "$ac_python_libdir" -a -n "$ac_python_library"
+		then
+			# use the official shared library
+			ac_python_library=`echo "$ac_python_library" | sed "s/^lib//"`
+			PYTHON_LIBS="-L$ac_python_libdir -l$ac_python_library"
+		else
+			# old way: use libpython from python_configdir
+			ac_python_libdir=`$PYTHON -c \
+			  "from distutils.sysconfig import get_python_lib as f; \
+			  import os; \
+			  print (os.path.join(f(plat_specific=1, standard_lib=1), 'config'));"`
+			PYTHON_LIBS="-L$ac_python_libdir -lpython$ac_python_version"
+		fi
+
+		if test -z "PYTHON_LIBS"; then
+			AC_MSG_ERROR([
+  Cannot determine location of your Python DSO. Please check it was installed with
+  dynamic libraries enabled, or try setting PYTHON_LIBS by hand.
+			])
+		fi
+	fi
+	AC_MSG_RESULT([$PYTHON_LIBS])
+	AC_SUBST([PYTHON_LIBS])
+
+	#
+	# Check for site packages
+	#
+	AC_MSG_CHECKING([for Python site-packages path])
+	if test -z "$PYTHON_SITE_PKG"; then
+		PYTHON_SITE_PKG=`$PYTHON -c "import distutils.sysconfig; \
+			print (distutils.sysconfig.get_python_lib(0,0));"`
+	fi
+	AC_MSG_RESULT([$PYTHON_SITE_PKG])
+	AC_SUBST([PYTHON_SITE_PKG])
+
+	#
+	# libraries which must be linked in when embedding
+	#
+	AC_MSG_CHECKING(python extra libraries)
+	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
+	   PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
+                conf = distutils.sysconfig.get_config_var; \
+                print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
+	fi
+	AC_MSG_RESULT([$PYTHON_EXTRA_LDFLAGS])
+	AC_SUBST(PYTHON_EXTRA_LDFLAGS)
+
+	#
+	# linking flags needed when embedding
+	#
+	AC_MSG_CHECKING(python extra linking flags)
+	if test -z "$PYTHON_EXTRA_LIBS"; then
+		PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+			conf = distutils.sysconfig.get_config_var; \
+			print (conf('LINKFORSHARED'))"`
+	fi
+	AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
+	AC_SUBST(PYTHON_EXTRA_LIBS)
+
+	#
+	# final check to see if everything compiles alright
+	#
+	AC_MSG_CHECKING([consistency of all components of python development environment])
+	# save current global flags
+	ac_save_LIBS="$LIBS"
+	ac_save_LDFLAGS="$LDFLAGS"
+	ac_save_CPPFLAGS="$CPPFLAGS"
+	LIBS="$ac_save_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS $PYTHON_EXTRA_LIBS"
+	LDFLAGS="$ac_save_LDFLAGS $PYTHON_EXTRA_LDFLAGS"
+	CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_CPPFLAGS"
+	AC_LANG_PUSH([C])
+	AC_LINK_IFELSE([
+		AC_LANG_PROGRAM([[#include <Python.h>]],
+				[[Py_Initialize();]])
+		],[pythonexists=yes],[pythonexists=no])
+	AC_LANG_POP([C])
+	# turn back to default flags
+	CPPFLAGS="$ac_save_CPPFLAGS"
+	LIBS="$ac_save_LIBS"
+	LDFLAGS="$ac_save_LDFLAGS"
+
+	AC_MSG_RESULT([$pythonexists])
+
+        if test ! "x$pythonexists" = "xyes"; then
+	   AC_MSG_FAILURE([
+  Could not link test program to Python. Maybe the main Python library has been
+  installed in some non-standard library path. If so, pass it to configure,
+  via the LIBS environment variable.
+  Example: ./configure LIBS="-L/usr/non-standard-path/python/lib"
+  ============================================================================
+   ERROR!
+   You probably have to install the development version of the Python package
+   for your distribution.  The exact name of this package varies among them.
+  ============================================================================
+	   ])
+	  PYTHON_VERSION=""
+	fi
+
+	#
+	# all done!
+	#
+])

--- a/man/distcc.1
+++ b/man/distcc.1
@@ -134,7 +134,7 @@ get increasing benefit with more server CPUs (up to the hundreds!).
 Wrap your build inside the pump command, here assuming 10 servers:
 
 .RS
-$ pump make -j20 CC=distcc
+$ distcc-pump make -j20 CC=distcc
 .RE
 
 .SH "QUICKSTART FOR DISTCC-GSSAPI MODE"
@@ -189,7 +189,7 @@ The compiler is then run from the path in the temporary directory that
 corresponds to the current working directory on the client.  To find and
 transmit the many hundreds of files that are often part of a single compilation,
 pump mode uses an incremental include analysis algorithm.  The include server is
-a Python program that implements this algorithm.  The pump command starts the
+a Python program that implements this algorithm.  The distcc-pump command starts the
 include server so that throughout the build it can answer include queries by
 distcc commands.
 .PP
@@ -569,7 +569,7 @@ Enables LZO compression for this TCP or SSH host.
 .TP
 .B ,cpp
 Enables distcc-pump mode for this host.  Note: the build command must be 
-wrapped in the pump script in order to start the include server.
+wrapped in the distcc-pump script in order to start the include server.
 .TP
 .B ,auth
 Enables GSSAPI-based mutual authentication for this host.
@@ -961,7 +961,7 @@ Other known bugs may be documented on
 distcc was written by Martin Pool <mbp@sourcefrog.net>, with the
 co-operation of many scholars including Wayne Davison, Frerich Raabe,
 Dimitri Papadopoulos and others noted in the NEWS file.  Please report
-bugs to <distcc@lists.samba.org>.  See \fBpump\fR(1) for the authors of pump mode.
+bugs to <distcc@lists.samba.org>.  See \fBdistcc-pump\fR(1) for the authors of pump mode.
 .SH "LICENCE"
 You are free to use distcc.  distcc (including this manual) may be
 copied, modified or distributed only under the terms of the GNU
@@ -969,7 +969,7 @@ General Public Licence version 2 or later.  distcc comes with
 absolutely no warrany.  A copy of the GPL is included in the file
 COPYING.
 .SH "SEE ALSO"
-\fBdistccd\fR(1), \fBpump\fR(1), \fBinclude_server\fR(1), \fBgcc\fR(1),
+\fBdistccd\fR(1), \fBdistcc-pump\fR(1), \fBinclude_server\fR(1), \fBgcc\fR(1),
 \fBmake\fR(1), and  \fBccache\fR(1).
 .I http://code.google.com/p/distcc/
 .I http://ccache.samba.org/

--- a/man/pump.1
+++ b/man/pump.1
@@ -1,23 +1,23 @@
 .TH pump 1 "9 June 2008"
 .SH "NAME"
-pump \- accelerate remote compilation with distcc
+distcc-pump \- accelerate remote compilation with distcc
 .SH "SYNOPSIS"
-.B pump
+.B distcc-pump
 .I BUILD-COMMAND [ARGS]
 \& ...
 .BR
 .PP
 eval `
-.B pump
+.B distcc-pump
 --startup `;
 .I BUILD-COMMAND [ARGS]
 \& ...
 ;
-.B pump
+.B distcc-pump
 --shutdown
 .BR
 .SH "DESCRIPTION"
-.B pump
+.B distcc-pump
 is part of distcc.
 It is used for distcc's pump mode.
 Distcc's pump mode accelerates remote compilation with distcc
@@ -36,7 +36,7 @@ section.
 .PP
 The simplest usage is the form
 .RS
-.B pump
+.B distcc-pump
 .I COMMAND [ARG]
 \& ...
 .RE
@@ -45,7 +45,7 @@ optionally run
 .B lsdistcc
 to compute the distcc host list;
 set some auxiliary environment variables;
-change PATH to use the distcc client in the same directory as the "pump"
+change PATH to use the distcc client in the same directory as the "distcc-pump"
 script;
 execute
 .I COMMAND
@@ -59,23 +59,23 @@ is typically a parallel build command, such as
 "make -j80", that will do many concurrent invocations of distcc.
 .PP
 An alternative way of invoking
-.B pump
-is to explicitly invoke "pump --startup"
-to start the include server and "pump --shutdown" to stop the include server.
-The "pump --startup" command will start up the include server, and will print
+.B distcc-pump
+is to explicitly invoke "distcc-pump --startup"
+to start the include server and "distcc-pump --shutdown" to stop the include server.
+The "distcc-pump --startup" command will start up the include server, and will print
 out some environment variable settings.  These environment variables are used
 to communicate between the pump-mode "distcc" client and the include
-server, and to communicate between "pump --startup" and "pump --shutdown".
-The caller of "pump --startup" is responsible for setting those environment
-variables before invoking "distcc" or "pump --shutdown".
+server, and to communicate between "distcc-pump --startup" and "distcc-pump --shutdown".
+The caller of "distcc-pump --startup" is responsible for setting those environment
+variables before invoking "distcc" or "distcc-pump --shutdown".
 .PP
 For example:
 .RS
-eval `pump --startup`
+eval `distcc-pump --startup`
 .br
 make -j80
 .br
-pump --shutdown
+distcc-pump --shutdown
 .RE
 .PP
 Note that distcc's pump-mode assumes that sources files will not be
@@ -84,13 +84,13 @@ the lifetime of the include server, so modifying source files during a build
 may cause inconsistent results.
 .SH "INVOKING LSDISTCC"
 When invoked in either the simple "
-.B pump
+.B distcc-pump
 .I COMMAND [ARG]
 \&... " form,
 or as "
-.B pump --startup
+.B distcc-pump --startup
 \&", the
-.B pump
+.B distcc-pump
 script will invoke
 .B lsdistcc
 \& whenever DISTCC_POTENTIAL_HOSTS is set and DISTCC_HOSTS isn't.
@@ -109,12 +109,12 @@ Starts an include server, and outputs the environment variable settings
 needed for
 .BR distcc(1)
 or
-.B pump --shutdown
+.B distcc-pump --shutdown
 to access it.
 .TP
 .B --shutdown
 Shuts down an include server started up by
-.B pump --startup.
+.B distcc-pump --startup.
 .SH "ENVIRONMENT VARIABLES"
 The following environment variables are all optional.
 .TP
@@ -159,7 +159,7 @@ Extra arguments to pass to the include server.
 PYTHONOPTIMIZE
 If set to "", then Python optimization is disabled.
 .SH "EXAMPLE"
-.B pump make -j20
+.B distcc-pump make -j20
 .SH "BUGS"
 .\" TODO:
 .\" Fix inconsistency between BUGS section and bug reporting instructions
@@ -168,11 +168,11 @@ If you think you have found a distcc bug, please see the file
 .I reporting-bugs.txt
 in the documentation directory for information on how to report it.
 .SH "AUTHORS"
-The pump script and distcc's pump mode were written by Nils Klarlund,
+The distcc-pump script and distcc's pump mode were written by Nils Klarlund,
 Manos Renieris, Fergus Henderson, and Craig Silverstein. Please report
 bugs to <distcc@lists.samba.org>.
 .SH "LICENCE"
-.B pump
+.B distcc-pump
 is part of distcc.
 You are free to use distcc.  distcc (including this manual) may be
 copied, modified or distributed only under the terms of the GNU

--- a/popt/popt.c
+++ b/popt/popt.c
@@ -1081,6 +1081,7 @@ int poptAddAlias(poptContext con, struct poptAlias alias,
 		/*@unused@*/ int flags)
 {
     poptItem item = alloca(sizeof(*item));
+    UNUSED(flags)
     memset(item, 0, sizeof(*item));
     item->option.longName = alias.longName;
     item->option.shortName = alias.shortName;

--- a/popt/popt.h
+++ b/popt/popt.h
@@ -11,6 +11,8 @@
 
 #include <stdio.h>			/* for FILE * */
 
+#define UNUSED(x) {(void)x;}
+
 #define POPT_OPTION_DEPTH	10
 
 /** \ingroup popt

--- a/popt/poptconfig.c
+++ b/popt/poptconfig.c
@@ -167,6 +167,7 @@ int poptReadDefaultConfig(poptContext con, /*@unused@*/ int useEnv)
 {
     char * fn, * home;
     int rc;
+    UNUSED(useEnv)
 
     /*@-type@*/
     if (!con->appName) return 0;

--- a/popt/popthelp.c
+++ b/popt/popthelp.c
@@ -27,6 +27,9 @@ static void displayArgs(poptContext con,
 	/*@globals fileSystem@*/
 	/*@modifies fileSystem@*/
 {
+    UNUSED(foo)
+    UNUSED(arg)
+    UNUSED(data)
     if (key->shortName == '?')
 	poptPrintHelp(con, stdout, 0);
     else
@@ -92,6 +95,7 @@ getArgDescrip(const struct poptOption * opt,
 		/*@=paramuse@*/
 	/*@*/
 {
+    UNUSED(translation_domain)
     if (!(opt->argInfo & POPT_ARG_MASK)) return NULL;
 
     if (opt == (poptHelpOptions + 1) || opt == (poptHelpOptions + 2))
@@ -133,6 +137,7 @@ singleOptionDefaultValue(int lineLength,
     const char * defstr = D_(translation_domain, "default");
     char * le = malloc(4*lineLength + 1);
     char * l = le;
+    UNUSED(translation_domain)
 
     if (le == NULL) return NULL;	/* XXX can't happen */
 /*@-boundswrite@*/
@@ -502,6 +507,7 @@ static int showHelpIntro(poptContext con, FILE * fp)
 void poptPrintHelp(poptContext con, FILE * fp, /*@unused@*/ int flags)
 {
     int leftColWidth;
+    UNUSED(flags)
 
     (void) showHelpIntro(con, fp);
     if (con->otherHelp)
@@ -711,6 +717,7 @@ void poptPrintUsage(poptContext con, FILE * fp, /*@unused@*/ int flags)
 {
     poptDone done = memset(alloca(sizeof(*done)), 0, sizeof(*done));
     int cursor;
+    UNUSED(flags)
 
     done->nopts = 0;
     done->maxopts = 64;

--- a/popt/poptparse.c
+++ b/popt/poptparse.c
@@ -139,6 +139,7 @@ int poptConfigFileToString(FILE *fp, char ** argstrp, /*@unused@*/ int flags)
     size_t linelen;
     int maxargvlen = 480;
     int linenum = 0;
+    UNUSED(flags)
 
     *argstrp = NULL;
 

--- a/src/setuid.c
+++ b/src/setuid.c
@@ -35,7 +35,7 @@
 #include "exitcode.h"
 
 
-const char *opt_user = "distcc";
+const char *opt_user = "distccd";
 
 
 /**


### PR DESCRIPTION
GCC complains about unused arguments in popt library if -Werror is on (which is the default configuration). Add a UNUSED macro in popt.h and apply it on every unused argument.
