### PR TITLE
FIX: NULL is undeclared without stddef.h so the MAP_FAILED test fails

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -386,6 +386,7 @@ AC_CHECK_DECLS([snprintf, vsnprintf, vasprintf, asprintf, strndup])
 
 AC_MSG_CHECKING([if mmap() supports MAP_FAILED])
 AC_TRY_COMPILE([
+#include <stddef.h>
 #ifdef HAVE_SYS_MMAN_H
 #  include <sys/mman.h>
 #endif],[


### PR DESCRIPTION
The "if mmap() supports MAP_FAILED" test in configure.ac didn't include <stddef.h> leaving NULL undeclared on most modern (at least the ones I tested) C compilers, and therefore the test always failing.
