### PR TITLE
fix Issue #145. Allow -j (jobs) param to set number slots when used in zeroconf mode.

### DIFF
--- a/man/distccd.1
+++ b/man/distccd.1
@@ -215,6 +215,8 @@ DNS Service Discovery (DNS-SD).  This allows distcc clients on the local
 network to access this distccd server without explicitly listing its host
 name or IP address in their distcc host list: the distcc clients can
 just use "+zeroconf" in their distcc host lists.
+Can optionally use -j parameter to specify the maximum number of jobs
+that this server can process concurrently.
 .B This option is only available if distccd was compiled with
 .B Avahi support enabled.
 .TP

--- a/src/dparent.c
+++ b/src/dparent.c
@@ -141,7 +141,7 @@ int dcc_standalone_server(void)
 #ifdef HAVE_AVAHI
     /* Zeroconf registration */
     if (opt_zeroconf) {
-        if (!(avahi = dcc_zeroconf_register((uint16_t) arg_port, n_cpus)))
+        if (!(avahi = dcc_zeroconf_register((uint16_t) arg_port, n_cpus, dcc_max_kids)))
             return EXIT_CONNECT_FAILED;
     }
 #endif

--- a/src/zeroconf.h
+++ b/src/zeroconf.h
@@ -25,7 +25,7 @@
 
 int dcc_zeroconf_add_hosts(struct dcc_hostdef **re_list, int *ret_nhosts, int slots, struct dcc_hostdef **ret_prev);
 
-void *dcc_zeroconf_register(uint16_t port, int n_cpus);
+void *dcc_zeroconf_register(uint16_t port, int n_cpus, int n_jobs);
 int dcc_zeroconf_unregister(void*);
 
 char* dcc_get_gcc_version(char *s, size_t nbytes);


### PR DESCRIPTION
If server is started in zeroconf mode, the previous behavior was that the number of slots for any server was hardcoded to 4 * number of cpus.  This made zeroconf impracticle when different hosts had different core counts.
This commit allows distccd to be invoked in zeroconf mode with the -j parameter to specify total slots for the particular server being invoked.
If no -j specified, then this host will publish its total number of slots to be 2 * number of cores + 2.  (Note: this is the same behavior as when invoking a non-zerconf server without specifying -j.)
To maintain backward compatibily, if a distccd zeroconf server doesn't publish a value for slots, then it will be assigned a default total slots equal to the previous behavior of 4 * number of cores.
Note that the meaning of "slots" in the code now always refers to the number of slots per host.  (The previous interepration of "slots" was inconsistent, because sometimes it meant the number of slots per core.)