### PR TITLE
Portability fixes for distcc

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -19,6 +19,11 @@ QUICK SUMMARY
    Note that past versions of Debian used binutils-dev instead of
    libiberty-dev.
 
+   Note that distcc-pump needs Python 3.x, while the default version of
+   Python on many systems is 2.x, so you may have to be explicit - e.g.
+
+       sudo apt-get install libpython3.5-dev
+
 1. Build and install
 
       ./autogen.sh       # If "configure" does not already exist.

--- a/configure.ac
+++ b/configure.ac
@@ -48,10 +48,10 @@ AC_CHECK_TYPE([socklen_t], ,[
 	AC_MSG_CHECKING([for socklen_t equivalent])
 	AC_CACHE_VAL([dcc_cv_socklen_t_equiv],
 	[
-	# Systems have either "struct sockaddr *" or
+	# Systems have either "struct sockaddr{,_in} *" or
 	# "void *" as the second argument to getpeername
 	dcc_cv_socklen_t_equiv=
-	for arg2 in "struct sockaddr" void; do
+	for arg2 in "struct sockaddr_in" "struct sockaddr" void; do
 		for t in int size_t unsigned long "unsigned long"; do
 			AC_TRY_COMPILE([
 #include <sys/types.h>

--- a/configure.ac
+++ b/configure.ac
@@ -502,7 +502,7 @@ AC_ARG_WITH([auth],
 
 if test x"$with_auth" = xyes; then
         AC_SEARCH_LIBS([gss_init_sec_context],
-                        [gssapi gssapi_krb5],
+                        [gssapi gssapi_krb5 gss],
 	                AC_DEFINE(HAVE_GSSAPI, 1, [Define if the GSS_API is available])
 	                AUTH_COMMON_OBJS="src/auth_common.o"
 	                AUTH_DISTCC_OBJS="src/auth_distcc.o"

--- a/src/auth_distcc.c
+++ b/src/auth_distcc.c
@@ -128,7 +128,7 @@ static int dcc_gssapi_establish_secure_context(int to_net_sd,
 
     addr_len = sizeof(addr);
 
-    if ((ret = getpeername(to_net_sd, &addr, &addr_len)) != 0) {
+    if ((ret = getpeername(to_net_sd, (struct sockaddr *)&addr, &addr_len)) != 0) {
         rs_log_error("Failed to look up peer address using socket \"%d\": %s.",
                      to_net_sd,
                      hstrerror(h_errno));

--- a/src/zeroconf-reg.c
+++ b/src/zeroconf-reg.c
@@ -100,7 +100,7 @@ static void register_stuff(struct context *ctx) {
                     "gnuhost="GNU_HOST,
                     v ? version : NULL,
                     m ? machine : NULL,
-                    NULL) < 0) {
+                    (void*)NULL) < 0) {
             rs_log_crit("Failed to add service: %s\n", avahi_strerror(avahi_client_errno(ctx->client)));
             goto fail;
         }

--- a/src/zeroconf.c
+++ b/src/zeroconf.c
@@ -25,6 +25,7 @@
 #include <sys/select.h>
 #include <signal.h>
 #include <sys/file.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #include <time.h>
 #include <sys/stat.h>


### PR DESCRIPTION
These pedantic fixes and configure-variants extensions were required for compilation on OpenIndiana Hipster. Verified that build succeeds on Debian 8 with these in place.
