### PR TITLE
Add tracis-ci.org Build To distcc Project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install: 
  - sudo apt-get update -qq
- - sudo apt-get install -qq make binutils-dev gcc-dev
+ - sudo apt-get install -qq make binutils-dev
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install: 
  - sudo apt-get update -qq
- - sudo apt-get install -qq make libiberty-dev
+ - sudo apt-get install -qq make binutils-dev gcc-dev
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+before_install: 
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq make 
+
+language: cpp
+
+before_script: ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install: 
  - sudo apt-get update -qq
- - sudo apt-get install -qq make 
+ - sudo apt-get install -qq make libiberty-dev
 
 language: cpp
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 by Martin Pool
 
-http://distcc.org/
+Current Docuemnts: https://cdn.rawgit.com/distcc/distcc/9a09372bd3f420cdd7021e52eda14fa536a3c10e/doc/web/index.html
+Formally http://distcc.org/
 
 "pump" functionality added by
 Fergus Henderson, Nils Klarlund, Manos Renieris, and Craig Silverstein (Google Inc.)


### PR DESCRIPTION
These changes add a .travis.yml file to the root directory of the project.  With this in place it would be possible for an administrator to start a travis-ci.org build for the project to cover a Debian/Ubuntu native build.  The service is free for Open Source projects. 

As I am not very good at using GitHub there is also ee86ccf on the end.  This updates the web documentation link as suggested by @n1tehawk under #157 