### PR TITLE
Add fallthrough comment to avoid GCC 7 error

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -469,6 +469,7 @@ static void dcc_stats_process(struct statsdata *sd) {
         break;
     case STATS_COMPILE_OK:
         dcc_stats_update_compile_times(sd);
+        /* fallthrough */
     case STATS_COMPILE_ERROR:
     case STATS_COMPILE_TIMEOUT:
     case STATS_CLI_DISCONN:


### PR DESCRIPTION
Adding a comment should be enough to avoid GCC 7 error on fallthrough in switch statement. Alternatively one can use C++17 attribute which is available in C++11 and C++15 under `gnu::` or in general GNU attribute syntax.