### PR TITLE
Fix compilation with musl libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,7 @@ AC_C_BIGENDIAN
 
 # Some of these are needed by popt (or other libraries included in the future).
 
-AC_CHECK_HEADERS([unistd.h sys/types.h sys/sendfile.h sys/signal.h])
+AC_CHECK_HEADERS([unistd.h sys/types.h sys/sendfile.h])
 AC_CHECK_HEADERS([ctype.h sys/resource.h sys/socket.h sys/select.h])
 AC_CHECK_HEADERS([netinet/in.h], [], [],
 [#if HAVE_SYS_TYPES_H

--- a/src/access.c
+++ b/src/access.c
@@ -52,7 +52,9 @@
  */
 
 static const uint32_t allones = 0xffffffffUL;
+#ifdef ENABLE_RFC2553
 static const uint8_t allones8 = 0xffU;
+#endif
 
 /**
  * Split a "HOST/BITS" mask specification into HOST and BITS.

--- a/src/clinet.c
+++ b/src/clinet.c
@@ -35,9 +35,9 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <poll.h>
 #include <signal.h>
 
-#include <sys/poll.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/exec.c
+++ b/src/exec.c
@@ -51,6 +51,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <poll.h>
 #include <signal.h>
 
 #include <sys/types.h>
@@ -58,7 +59,6 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <sys/poll.h>
 
 #ifdef __CYGWIN__
     #define NOGDI

--- a/src/lsdistcc.c
+++ b/src/lsdistcc.c
@@ -88,7 +88,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <netinet/in.h>

--- a/src/rslave.c
+++ b/src/rslave.c
@@ -30,7 +30,7 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 
 #include "rslave.h"

--- a/src/serve.c
+++ b/src/serve.c
@@ -61,15 +61,11 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <signal.h>
 #include <time.h>
 
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#ifdef HAVE_SYS_SIGNAL_H
-#  include <sys/signal.h>
-#endif /* HAVE_SYS_SIGNAL_H */
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/time.h>

--- a/src/zeroconf.c
+++ b/src/zeroconf.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <fcntl.h>
 
 #include <avahi-common/domain.h>
 #include <avahi-common/error.h>


### PR DESCRIPTION
Only the first commit is strictly necessary; the other commits fix compilation with -Werror. (musl warns when <sys/poll.h> or <sys/signal.h> is used.)