### PR TITLE
Correct Code Link In README

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 
 	  distcc -- a free distributed C/C++ compiler system
 
-		   http://code.google.com/p/distcc/
+		   https://github.com/distcc/distcc
 
 		    by Martin Pool <mbp@samba.org>
 


### PR DESCRIPTION
The README text file had the old Google Code project link in it.  This project migrated to GitHub following the closure of the Google Code services.