### PR TITLE
Add requirements and document defaults, add matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,30 @@ addons:
         packages:
             - python3-dev
             - libiberty-dev
+            - libavahi-client-dev
+            - musl-tools
+
+os:
+    - linux
+
+compiler:
+    - gcc
+
+matrix:
+    include:
+        - os: linux
+          compiler: gcc
+          env: OPTIONS=""
+        - os: linux
+          compiler: gcc
+          env: OPTIONS="--with-auth"
+        - os: linux
+          compiler: musl-gcc
+          env: OPTIONS="--without-libiberty --without-avahi"
+          sudo: required        # for ping (travis-ci #3080)
 
 before_script: ./autogen.sh
 
 script:
-    - ./configure
+    - ./configure $OPTIONS
     - make check


### PR DESCRIPTION
Default platform is linux and gcc, maybe osx later.

Unfortunately can't test things like BSD / Cygwin.

Make sure to include requirements for all defaults.

Don't bother checking the extras like gnome or gtk.

Closes #222.