### PR TITLE
Extend Travis CI configuration for macOS/clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.o
 *.d
+*.out
+*.err
 # binaries
 distcc
 distccd
@@ -21,3 +23,4 @@ src/config.h
 src/config.h.in
 src/config.h.stamp
 man/*.gz
+_testtmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,44 @@
 language: c
 
 addons:
-    apt:
-        packages:
-            - python3-dev
-            - libiberty-dev
+  apt:
+    packages:
+      - python3-dev
+      - libiberty-dev
 
-before_script: ./autogen.sh
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
 script:
-    - ./configure
-    - make check
+  - ./autogen.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure --without-libiberty; fi
+  - make
+  - make check
+
+matrix:
+  allow_failures:
+    - compiler: clang
+      env: FIXME=1
+  include:
+  - os: linux
+    compiler: gcc
+    dist: trusty
+  - os: linux
+    compiler: clang
+    env: FIXME=1
+    dist: trusty
+  - os: osx
+    osx_image: xcode8.2
+    env:
+      - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+  - os: osx
+    osx_image: xcode8.2
+    compiler: clang
+  - os: osx
+    osx_image: xcode8.3
+    compiler: clang
+  - os: osx
+    osx_image: xcode9
+    compiler: clang

--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,8 @@ then
 -Wno-write-strings"
 
     # For popt/*.c, we disable unused variable warnings.
-    POPT_CFLAGS="-Wno-unused"
+    # When using Apple GCC/Clang you have to explicitly disable unused parameters.
+    POPT_CFLAGS="-Wno-unused -Wno-unused-parameter"
 
     AC_MSG_NOTICE([Adding gcc options: $CFLAGS])
 fi

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+# Building distcc with different compilers
+
+## Requirements:
+
+Docker 1.9.1
+
+## Build
+The following command will create three images based on Ubuntu 16.04 using gcc 4.8, 5.4 and clang 3.8 and
+build distcc inside the container.
+
+```
+$ cd docker
+$ ./build.sh
+```
+
+In order to build only one variant use the following command:
+
+```
+$ cd docker
+$ ./build.sh clang-3.8|gcc-4.8|gcc-5
+```

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:xenial-20170802
+
+LABEL maintainer=""
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY apt-conf /etc/apt/apt.conf.d/
+
+RUN apt-get update && \
+    apt-get install autoconf \
+                    python3-dev \
+                    python-dev \
+                    libiberty-dev \
+                    build-essential \
+                    make

--- a/docker/base/apt-conf
+++ b/docker/base/apt-conf
@@ -1,0 +1,4 @@
+APT::Get::Assume-Yes "true";
+APT::Get::Install-Recommends "false";
+APT::Get::Install-Suggests "false";
+DPkg::Post-Invoke { "rm -rf /var/lib/apt/lists/* || true"; };

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e # exit immediately if a command returns with a nonzero exit code
+
+echo "*** Building distcc/base image"
+docker build -t distcc/base -f base/Dockerfile base
+
+if [ $# -eq 0 ]; then
+  compilers=("gcc-4.8" "gcc-5" "clang-3.8")
+else
+  compilers=("$1")
+fi
+
+for compiler in "${compilers[@]}"
+do
+  echo "*** Building distcc/$compiler image"
+  docker build -t distcc/$compiler -f compilers/Dockerfile.$compiler .
+done
+
+echo "*** Building distcc"
+for compiler in "${compilers[@]}"
+do
+  echo "*** Building distcc with distcc/$compiler image"
+  set -x
+  docker run --rm -it -v /tmp:/tmp -v `pwd`/..:/src:rw -w /src distcc/$compiler bash -c "./autogen.sh && ./configure && make clean && make && make install && make check" &> distcc-$compiler.log
+  set +x
+done

--- a/docker/compilers/Dockerfile.clang-3.8
+++ b/docker/compilers/Dockerfile.clang-3.8
@@ -1,0 +1,9 @@
+FROM distcc/base
+
+LABEL maintainer=""
+
+RUN apt-get update && \
+    apt-get install clang-3.8 build-essential && \
+    apt-get remove gcc g++ && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 50 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-3.8 50

--- a/docker/compilers/Dockerfile.gcc-4.8
+++ b/docker/compilers/Dockerfile.gcc-4.8
@@ -1,0 +1,11 @@
+FROM distcc/base
+
+LABEL maintainer=""
+
+RUN apt-get update && \
+    apt-get install gcc-4.8 \
+                    gcc-multilib \
+                    g++-4.8 \
+                    g++-multilib && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.8 50

--- a/docker/compilers/Dockerfile.gcc-5
+++ b/docker/compilers/Dockerfile.gcc-5
@@ -1,0 +1,11 @@
+FROM distcc/base
+
+LABEL maintainer=""
+
+RUN apt-get update && \
+    apt-get install gcc-5 \
+                    gcc-multilib \
+                    g++-5 \
+                    g++-multilib && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 50 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-5 50


### PR DESCRIPTION
This is an attempt to extend the Travis CI configuration for building distcc on macOS using Clang. In order to get it working I needed to adjust as well some tests to cope with clang as well.

Apart from that I have created as well some Dockerfile's to easily run builds in an isolated environment (also nice for macOS users)