### PR TITLE
daemon: add seccomp filter on Linux

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -268,6 +268,7 @@ distccd_obj = src/access.o						\
 	src/stringmap.o							\
 	src/serve.o src/setuid.o src/srvnet.o src/srvrpc.o src/state.o	\
 	src/stats.o							\
+	src/sandbox-seccomp-filter.o					\
 	src/fix_debug_info.o						\
 	@ZEROCONF_DISTCCD_OBJS@						\
 	@AUTH_DISTCCD_OBJS@						\
@@ -330,6 +331,7 @@ SRC =	src/stats.c							\
 	src/loadfile.c src/lock.c 					\
 	src/mon.c src/mon-notify.c src/mon-text.c			\
 	src/mon-gnome.c							\
+	src/sandbox-seccomp-filter.c					\
 	src/ncpus.c src/netutil.c					\
 	src/prefork.c src/pump.c					\
 	src/remote.c src/renderer.c src/rpc.c				\

--- a/configure.ac
+++ b/configure.ac
@@ -466,6 +466,59 @@ if test x"$rsync_cv_HAVE_SOCKETPAIR" = x"yes"; then
     AC_DEFINE(HAVE_SOCKETPAIR, 1, [define if you have a working socketpair])
 fi
 
+AC_CHECK_HEADERS([linux/seccomp.h linux/filter.h linux/audit.h], [],
+    [], [#include <linux/types.h>])
+AC_MSG_CHECKING([for seccomp architecture])
+seccomp_audit_arch=
+case "$host" in
+x86_64-*)
+	seccomp_audit_arch=AUDIT_ARCH_X86_64
+	;;
+i*86-*)
+	seccomp_audit_arch=AUDIT_ARCH_I386
+	;;
+arm*-*)
+	seccomp_audit_arch=AUDIT_ARCH_ARM
+	;;
+aarch64*-*)
+	seccomp_audit_arch=AUDIT_ARCH_AARCH64
+	;;
+s390x-*)
+	seccomp_audit_arch=AUDIT_ARCH_S390X
+	;;
+s390-*)
+	seccomp_audit_arch=AUDIT_ARCH_S390
+	;;
+powerpc64-*)
+	seccomp_audit_arch=AUDIT_ARCH_PPC64
+	;;
+powerpc64le-*)
+	seccomp_audit_arch=AUDIT_ARCH_PPC64LE
+	;;
+mips-*)
+	seccomp_audit_arch=AUDIT_ARCH_MIPS
+	;;
+mipsel-*)
+	seccomp_audit_arch=AUDIT_ARCH_MIPSEL
+	;;
+mips64-*)
+	seccomp_audit_arch=AUDIT_ARCH_MIPS64
+	;;
+mips64el-*)
+	seccomp_audit_arch=AUDIT_ARCH_MIPSEL64
+	;;
+esac
+if test "x$seccomp_audit_arch" != "x" ; then
+	AC_MSG_RESULT(["$seccomp_audit_arch"])
+	AC_DEFINE_UNQUOTED([SECCOMP_AUDIT_ARCH], [$seccomp_audit_arch],
+	    [Specify the system call convention in use])
+	CFLAGS="$CFLAGS -DSECCOMP_AUDIT_ARCH=$seccomp_audit_arch"
+	AC_DEFINE(HAVE_SECCOMP_FILTER, 1, [define if you have seccomp filter mode])
+	CFLAGS="$CFLAGS -DHAVE_SECCOMP_FILTER"
+else
+	AC_MSG_RESULT([architecture not supported])
+fi
+
 dnl Checks for structures
 AC_CHECK_MEMBER([struct sockaddr_storage.ss_family],
     AC_DEFINE(HAVE_SOCKADDR_STORAGE, 1, [define if you have struct sockaddr_storage]),,

--- a/src/dopt.c
+++ b/src/dopt.c
@@ -115,6 +115,11 @@ enum {
 int opt_zeroconf = 0;
 #endif
 
+#ifdef HAVE_SECCOMP_FILTER
+/* Flag for enabling/disabling Zeroconf using Avahi */
+int opt_no_seccomp = 0;
+#endif
+
 const struct poptOption options[] = {
     { "allow", 'a',      POPT_ARG_STRING, 0, 'a', 0, 0 },
 #ifdef HAVE_GSSAPI
@@ -152,6 +157,9 @@ const struct poptOption options[] = {
 #ifdef HAVE_AVAHI
     { "zeroconf", 0,     POPT_ARG_NONE, &opt_zeroconf, 0, 0, 0 },
 #endif
+#ifdef HAVE_SECCOMP_FILTER
+    { "no-seccomp", 0,   POPT_ARG_NONE, &opt_no_seccomp, 0, 0, 0 },
+#endif
     { 0, 0, 0, 0, 0, 0, 0 }
 };
 
@@ -186,6 +194,9 @@ static void distccd_show_usage(void)
 "    --stats-port PORT          TCP port to listen on for statistics requests\n"
 #ifdef HAVE_AVAHI
 "    --zeroconf                 register via mDNS/DNS-SD\n"
+#endif
+#ifdef HAVE_SECCOMP_FILTER
+"    --no-seccomp               do not sandbox\n"
 #endif
 "  Debug and trace:\n"
 "    --log-level=LEVEL          set detail level for log file\n"

--- a/src/dopt.h
+++ b/src/dopt.h
@@ -48,6 +48,10 @@ extern int opt_niceness;
 extern int opt_zeroconf;
 #endif
 
+#ifdef HAVE_SECCOMP_FILTER
+extern int opt_no_seccomp;
+#endif
+
 #ifdef HAVE_GSSAPI
 extern int dcc_auth_enabled;
 #endif

--- a/src/dparent.c
+++ b/src/dparent.c
@@ -74,6 +74,10 @@
 #ifdef HAVE_GSSAPI
 #include "auth.h"
 #endif
+#ifdef HAVE_SECCOMP_FILTER
+#include "sandbox-seccomp-filter.h"
+#include "dopt.h"
+#endif
 
 static void dcc_nofork_parent(int listen_fd) NORETURN;
 static void dcc_detach(void);
@@ -149,6 +153,11 @@ int dcc_standalone_server(void)
     /* This is called in the master daemon, whether that is detached or
      * not.  */
     dcc_master_pid = getpid();
+
+#ifdef HAVE_SECCOMP_FILTER
+    if (!opt_no_seccomp)
+        dcc_seccomp_sandbox_filter();
+#endif
 
     if (opt_no_fork) {
         dcc_log_daemon_started("non-forking daemon");

--- a/src/sandbox-seccomp-filter.c
+++ b/src/sandbox-seccomp-filter.c
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2017 Shawn Landden <slandden@gmail.com>
+ * based on openssh-portable sandbox: Copyright (c) 2012 Will Drewry <wad@dataspill.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Uncomment the SANDBOX_SECCOMP_FILTER_DEBUG macro below to help diagnose
+ * filter breakage during development. *Do not* use this in production,
+ * as it relies on making library calls that are unsafe in signal context.
+ *
+ * Instead, live systems the auditctl(8) may be used to monitor failures.
+ * E.g.
+ *   auditctl -a task,always -F uid=<privsep uid>
+ */
+/* #define SANDBOX_SECCOMP_FILTER_DEBUG 1 */
+
+/* XXX it should be possible to do logging via the log socket safely */
+
+#ifdef HAVE_SECCOMP_FILTER
+
+#include <sys/types.h>
+#include <sys/resource.h>
+#include <sys/prctl.h>
+
+#include <linux/net.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <elf.h>
+
+#include <asm/unistd.h>
+#ifdef __s390__
+#include <asm/zcrypt.h>
+#endif
+
+#include <errno.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stddef.h>  /* for offsetof */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <asm-generic/ioctls.h>
+
+#include "sandbox-seccomp-filter.h"
+#include "trace.h"
+
+/* Linux seccomp_filter sandbox */
+#define SECCOMP_FILTER_FAIL SECCOMP_RET_KILL
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+# define ARG_LO_OFFSET  0
+# define ARG_HI_OFFSET  sizeof(uint32_t)
+#elif __BYTE_ORDER == __BIG_ENDIAN
+# define ARG_LO_OFFSET  sizeof(uint32_t)
+# define ARG_HI_OFFSET  0
+#else
+#error "Unknown endianness"
+#endif
+
+/* Simple helpers to avoid manual errors (but larger BPF programs). */
+#define SC_DENY(_nr, _errno) \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 1), \
+	BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ERRNO|(_errno))
+#define SC_ALLOW(_nr) \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 1), \
+	BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW)
+#define SC_ALLOW_ARG(_nr, _arg_nr, _arg_val) \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 6), \
+	/* load and test first syscall argument, low word */ \
+	BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+	    offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_LO_OFFSET), \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, \
+	    ((_arg_val) & 0xFFFFFFFF), 0, 3), \
+	/* load and test first syscall argument, high word */ \
+	BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+	    offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_HI_OFFSET), \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, \
+	    (((uint32_t)((uint64_t)(_arg_val) >> 32)) & 0xFFFFFFFF), 0, 1), \
+	BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW), \
+	/* reload syscall number; all rules expect it in accumulator */ \
+	BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+		offsetof(struct seccomp_data, nr))
+
+/* Syscall filtering set for preauth. */
+static const struct sock_filter preauth_insns[] = {
+	/* Ensure the syscall arch convention is as expected. */
+	BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+		offsetof(struct seccomp_data, arch)),
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
+	BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+	/* Load the syscall number for checking. */
+	BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+		offsetof(struct seccomp_data, nr)),
+
+	/* Syscalls to permit */
+#ifdef __NR_brk
+	SC_ALLOW(__NR_brk),
+#endif
+#ifdef __NR_clock_gettime
+	SC_ALLOW(__NR_clock_gettime),
+#endif
+#ifdef __NR_close
+	SC_ALLOW(__NR_close),
+#endif
+#ifdef __NR_exit
+	SC_ALLOW(__NR_exit),
+#endif
+#ifdef __NR_exit_group
+	SC_ALLOW(__NR_exit_group),
+#endif
+#ifdef __NR_setpgid
+	SC_ALLOW(__NR_setpgid),
+#endif
+#ifdef __NR_getpgrp
+	SC_ALLOW(__NR_getpgrp),
+#endif
+#ifdef __NR_execve
+	SC_ALLOW(__NR_execve),
+#endif
+#ifdef __NR_open
+	SC_ALLOW(__NR_open),
+#endif
+#ifdef __NR_select
+	SC_ALLOW(__NR_select),
+#endif
+#ifdef __NR_readlink
+	SC_ALLOW(__NR_readlink),
+#endif
+#ifdef __NR_stat
+	SC_ALLOW(__NR_stat),
+#endif
+#ifdef __NR_lstat
+	SC_ALLOW(__NR_lstat),
+#endif
+#ifdef __NR_fstat
+	SC_ALLOW(__NR_fstat),
+#endif
+#ifdef __NR_unlink
+	SC_ALLOW(__NR_unlink),
+#endif
+#ifdef __NR_mkdir
+	SC_ALLOW(__NR_mkdir),
+#endif
+#ifdef __NR_rmdir
+	SC_ALLOW(__NR_rmdir),
+#endif
+#ifdef __NR_setsockopt
+	SC_ALLOW(__NR_setsockopt),
+#endif
+#ifdef __NR_getrandom
+	SC_ALLOW(__NR_getrandom),
+#endif
+#ifdef __NR_gettimeofday
+	SC_ALLOW(__NR_gettimeofday),
+#endif
+#ifdef __NR_madvise
+	SC_ALLOW(__NR_madvise),
+#endif
+#ifdef __NR_mmap
+	SC_ALLOW(__NR_mmap),
+#endif
+#ifdef __NR_mmap2
+	SC_ALLOW(__NR_mmap2),
+#endif
+#ifdef __NR_mremap
+	SC_ALLOW(__NR_mremap),
+#endif
+#ifdef __NR_munmap
+	SC_ALLOW(__NR_munmap),
+#endif
+#ifdef __NR_read
+	SC_ALLOW(__NR_read),
+#endif
+#ifdef __NR_write
+	SC_ALLOW(__NR_write),
+#endif
+#ifdef __NR_truncate
+	SC_ALLOW(__NR_truncate),
+#endif
+#ifdef __NR_rt_sigaction
+	SC_ALLOW(__NR_rt_sigaction),
+#endif
+#ifdef __NR_rt_sigreturn
+	SC_ALLOW(__NR_rt_sigreturn),
+#endif
+#ifdef __NR_rt_sigprocmask
+	SC_ALLOW(__NR_rt_sigprocmask),
+#endif
+#ifdef __NR_clone
+	SC_ALLOW(__NR_clone),
+#endif
+#ifdef __NR_getpid
+	SC_ALLOW(__NR_getpid),
+#endif
+#ifdef __NR_gettid
+	SC_ALLOW(__NR_gettid),
+#endif
+#ifdef __NR_getrusage
+	SC_ALLOW(__NR_getrusage),
+#endif
+#ifdef __NR_fork
+	SC_ALLOW(__NR_fork),
+#endif
+#ifdef __NR_nanosleep
+	SC_ALLOW(__NR_nanosleep),
+#endif
+#ifdef __NR_wait4
+	SC_ALLOW(__NR_wait4),
+#endif
+#ifdef __NR_set_robust_list
+	SC_ALLOW(__NR_set_robust_list),
+#endif
+#ifdef __NR_futex
+	SC_ALLOW(__NR_futex),
+#endif
+#ifdef __NR_accept
+	SC_ALLOW(__NR_accept),
+#endif
+#ifdef __NR_shmctl
+	SC_ALLOW(__NR_shmctl),
+#endif
+#ifdef __NR_access
+	SC_ALLOW(__NR_access),
+#endif
+#ifdef __NR_tgkill
+	SC_ALLOW(__NR_tgkill),
+#endif
+#ifdef __NR_kill
+	SC_ALLOW(__NR_kill),
+#endif
+#ifdef __NR_sendfile
+	SC_ALLOW(__NR_sendfile),
+#endif
+
+#ifdef __NR_mprotect
+	SC_ALLOW(__NR_mprotect),
+#endif
+#ifdef __NR_arch_prctl
+	SC_ALLOW(__NR_arch_prctl),
+#endif
+#ifdef __NR_set_tid_address
+	SC_ALLOW(__NR_set_tid_address),
+#endif
+#ifdef __NR_getrlimit
+	SC_ALLOW(__NR_getrlimit),
+#endif
+	SC_ALLOW(__NR_statfs),
+	SC_ALLOW_ARG(__NR_ioctl, 1, TCGETS),
+	SC_ALLOW(__NR_setrlimit),
+	SC_ALLOW(__NR_vfork),
+	SC_ALLOW(__NR_sysinfo),
+	SC_ALLOW(__NR_getcwd),
+	SC_ALLOW(__NR_fcntl),
+	SC_ALLOW(__NR_lseek),
+	SC_ALLOW(__NR_chdir),
+	SC_ALLOW(__NR_symlink),
+
+	SC_ALLOW(__NR_getdents),
+	SC_ALLOW(__NR_pread64),
+	SC_ALLOW(__NR_pipe2),
+	SC_ALLOW(__NR_rename),
+	SC_ALLOW(__NR_getdents),
+
+#if defined(__x86_64__) && defined(__ILP32__) && defined(__X32_SYSCALL_BIT)
+	/*
+	 * On Linux x32, the clock_gettime VDSO falls back to the
+	 * x86-64 syscall under some circumstances, e.g.
+	 * https://bugs.debian.org/849923
+	 */
+	SC_ALLOW(__NR_clock_gettime & ~__X32_SYSCALL_BIT),
+#endif
+
+	/* Default deny */
+	BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+};
+
+static const struct sock_fprog preauth_program = {
+	.len = (unsigned short)(sizeof(preauth_insns)/sizeof(preauth_insns[0])),
+	.filter = (struct sock_filter *)preauth_insns,
+};
+
+void
+dcc_seccomp_sandbox_filter()
+{
+	int nnp_failed = 0;
+
+	rs_log_info("%s: setting PR_SET_NO_NEW_PRIVS", __func__);
+	if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1) {
+		rs_log_info("%s: prctl(PR_SET_NO_NEW_PRIVS): %s",
+		      __func__, strerror(errno));
+		nnp_failed = 1;
+	}
+	rs_log_info("%s: attaching seccomp filter program", __func__);
+	if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &preauth_program) == -1)
+		rs_log_info("%s: prctl(PR_SET_SECCOMP): %s",
+		      __func__, strerror(errno));
+	else if (nnp_failed) {
+		rs_log_info("%s: SECCOMP_MODE_FILTER activated but "
+		    "PR_SET_NO_NEW_PRIVS failed", __func__);
+		exit(1);
+	}
+}
+
+#endif /* HAVE_SECCOMP_FILTER */

--- a/src/sandbox-seccomp-filter.h
+++ b/src/sandbox-seccomp-filter.h
@@ -1,0 +1,5 @@
+#ifdef HAVE_SECCOMP_FILTER
+#pragma once
+
+void dcc_seccomp_sandbox_filter(void);
+#endif


### PR DESCRIPTION
This makes distcc much more secure as it also applies to child processes
(gcc and clang).