### PR TITLE
cross-compilation support

### DIFF
--- a/man/distcc.1
+++ b/man/distcc.1
@@ -762,6 +762,11 @@ variable is set to 0 then fallbacks are disabled and those
 compilations will simply fail.  Note that this does not affect jobs
 which must always be local such as linking.
 .TP
+.B "DISTCC_NO_CROSS_REWRITE"
+By default distcc will rewrite calls gcc to use fully qualified names
+(like x86_64-linux-gnu-gcc), and clang to use the -target option. Setting this
+turns that off.
+.TP
 .B "DISTCC_BACKOFF_PERIOD"
 Specifies how long (in seconds) distcc will avoid trying to use a
 particular compilation server after that server yields a compile

--- a/src/compile.c
+++ b/src/compile.c
@@ -445,6 +445,92 @@ static int dcc_please_send_email_after_investigation(
     return dcc_note_discrepancy(discrepancy_filename);
 }
 
+/* Clang is a native cross-compiler, but needs to be told to what target it is
+ * building.
+ * TODO: actually probe clang with clang --version, instead of trusting
+ * autoheader.
+ */
+static void dcc_add_clang_target(char **argv)
+{
+        /* defined by autoheader */
+    const char *target = GNU_HOST;
+
+    if (strcmp(argv[0], "clang") == 0 || strncmp(argv[0], "clang-", strlen("clang-")) == 0 ||
+        strcmp(argv[0], "clang++") == 0 || strncmp(argv[0], "clang++-", strlen("clang++-")) == 0)
+        ;
+    else
+        return;
+
+    if (dcc_argv_search(argv, "-target"))
+        return;
+
+    rs_log_info("Adding '-target %s' to support clang cross-compilation.",
+                target);
+    dcc_argv_append(argv, strdup("-target"));
+    dcc_argv_append(argv, strdup(target));
+}
+
+/*
+ * Cross compilation for gcc
+*/
+static int dcc_gcc_rewrite_fqn(char **argv)
+{
+        /* defined by autoheader */
+    const char *target_with_vendor = GNU_HOST;
+    char *newcmd, *t, *path;
+    int pathlen = 0;
+
+    if (strcmp(argv[0], "gcc") == 0 || strncmp(argv[0], "gcc-", strlen("gcc-")) == 0 ||
+        strcmp(argv[0], "g++") == 0 || strncmp(argv[0], "g++-", strlen("g++-")) == 0)
+        ;
+    else
+        return -ENOENT;
+
+
+    newcmd = malloc(strlen(target_with_vendor) + 1 + strlen(argv[0] + 1));
+    if (!newcmd)
+        return -ENOMEM;
+
+    if ((t = strstr(target_with_vendor, "-pc-"))) {
+        strncpy(newcmd, target_with_vendor, t - target_with_vendor);
+        strcat(newcmd, t + strlen("-pc"));
+    } else
+        strcpy(newcmd, target_with_vendor);
+
+
+    strcat(newcmd, "-");
+    strcat(newcmd, argv[0]);
+
+    /* TODO, is this the right PATH? */
+    path = getenv("PATH");
+    do {
+        char binname[strlen(path) + 1 + strlen(newcmd) + 1];
+        int r;
+
+        /* emulate strchrnul() */
+        t = strchr(path, ':');
+        if (!t)
+            t = path + strlen(path);
+        pathlen = t - path;
+        if (*path == '\0')
+            return -ENOENT;
+        strncpy(binname, path, pathlen);
+        binname[pathlen] = '\0';
+        strcat(binname, "/");
+        strcat(binname, newcmd);
+        r = access(binname, X_OK);
+        if (r < 0)
+            continue;
+        /* good!, now rewrite */
+        rs_log_info("Re-writing call to '%s' to '%s' to support cross-compilation.",
+                    argv[0], newcmd);
+        free(argv[0]);
+        argv[0] = newcmd;
+        return 0;
+    } while ((path += pathlen + 1));
+    return -ENOENT;
+}
+
 /**
  * Execute the commands in argv remotely or locally as appropriate.
  *
@@ -521,6 +607,10 @@ dcc_build_somewhere(char *argv[],
     ret = dcc_scan_args(argv, &input_fname, &output_fname, &new_argv);
     dcc_free_argv(argv);
     argv = new_argv;
+    if (!getenv("DISTCC_NO_REWRITE_CROSS")) {
+        dcc_add_clang_target(new_argv);
+        dcc_gcc_rewrite_fqn(new_argv);
+    }
     if (ret != 0) {
         /* we need to scan the arguments even if we already know it's
          * local, so that we can pick up distcc client options. */

--- a/src/util.h
+++ b/src/util.h
@@ -49,6 +49,7 @@ int dcc_get_dns_domain(const char **domain_name);
 void dcc_get_proc_stats(int *num_D, int *max_RSS, char **max_RSS_name);
 void dcc_get_disk_io_stats(int *n_reads, int *n_writes);
 
+int dcc_which(const char *cmd, char **out);
 
 int dcc_dup_part(const char **psrc, char **pdst, const char *sep);
 


### PR DESCRIPTION
rewrites calls gcc to use fully qualified names
(like x86_64-linux-gnu-gcc), and fills in clang's -target option if it is not already filled in.