### PR TITLE
Create Brewfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ addons:
       - libiberty-dev
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew bundle; fi
 
 script:
   - ./autogen.sh

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew 'python3'

--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,3 @@
 brew 'python3'
+brew 'autoconf'
+brew 'automake'


### PR DESCRIPTION
moves osx dependencies out of `.travis.yml` and prevents errors from `brew install` if package is already installed (i.e. if travis changes the base `osx` image)