### PR TITLE
serve: have DISTCC_CMDLIST feature turns off access

### DIFF
--- a/src/serve.c
+++ b/src/serve.c
@@ -708,7 +708,9 @@ static int dcc_run_job(int in_fd,
     if ((ret = dcc_check_compiler_masq(argv[0])))
         goto out_cleanup;
 
-    if (!opt_make_me_a_botnet && dcc_check_compiler_whitelist(argv[0]))
+    if (!opt_make_me_a_botnet &&
+        !getenv("DISTCC_CMDLIST") &&
+        dcc_check_compiler_whitelist(argv[0]))
         goto out_cleanup;
 
     if ((compile_ret = dcc_spawn_child(argv, &cc_pid,


### PR DESCRIPTION
the not-very-used DISTCC_CMDLIST feature has its own whitelist.
Do not double-whitelist, which would be frustrating