### PR TITLE
Add Code Helpers Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # distcc -- a free distributed C/C++ compiler system
 [![Build Status](https://travis-ci.org/distcc/distcc.svg?branch=master)](https://travis-ci.org/distcc/distcc)
+[![Open Source Helpers](https://www.codetriage.com/distcc/distcc/badges/users.svg)](https://www.codetriage.com/distcc/distcc)
 
 by Martin Pool
 


### PR DESCRIPTION
The CodeTriage website (https://www.codetriage.com/) offers a simple way to encourage more people to actively participate in an Open Source project.  People have an option to sign up and get emailed a suggestion of N issues to work on periodically.  Adding a badge about the service to the ReadMe.md will display the service clearly.