### PR TITLE
Strip compiler arguments starting with '-isystem'

### DIFF
--- a/src/strip.c
+++ b/src/strip.c
@@ -107,7 +107,8 @@ int dcc_strip_local_args(char **from, char ***out_argv)
                  || str_startswith("-L", from[from_i])
                  || str_startswith("-MF", from[from_i])
                  || str_startswith("-MT", from[from_i])
-                 || str_startswith("-MQ", from[from_i])) {
+                 || str_startswith("-MQ", from[from_i])
+                 || str_startswith("-isystem", from[from_i])) {
             /* Something like "-DNDEBUG" or
              * "-Wp,-MD,.deps/nsinstall.pp".  Just skip this word */
             ;


### PR DESCRIPTION
The chromium build system (using clang) apparently concatenates
'-isystem' with path (i.e. uses it without space). Support stripping
this version as well to avoid the lot of warnings:

    x86_64-pc-linux-gnu-clang++-6.0: warning: argument unused during compilation: '-isystem /usr/include/nss' [-Wunused-command-line-argument]