### PR TITLE
Various patches mostly for cross-platform (Mac) support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -58,7 +58,7 @@ include_server_builddir = $(builddir)/_include_server
 
 # These must be done from here, not from autoconf, because they can 
 # contain variable expansions written in Make syntax.  Ew.
-DIR_DEFS = -DSYSCONFDIR="\"${sysconfdir}\"" -DPKGDATADIR="\"${pkgdatadir}\""
+DIR_DEFS = -DLIBDIR="\"${libdir}\"" -DSYSCONFDIR="\"${sysconfdir}\"" -DPKGDATADIR="\"${pkgdatadir}\""
 
 # arguments to pkgconfig
 GNOME_PACKAGES = @GNOME_PACKAGES@

--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,7 @@ AC_CHECK_FUNCS([strndup strsep mmap strlcpy])
 AC_CHECK_FUNCS([getloadavg])
 AC_CHECK_FUNCS([getline])
 
-AC_CHECK_FUNCS([fstatat],[],[AC_MSG_WARN([fstatat() not available; distccd will be slightly less secure])])
+AC_CHECK_FUNCS([fstatat])
 
 AC_CHECK_DECLS([snprintf, vsnprintf, vasprintf, asprintf, strndup])
 

--- a/configure.ac
+++ b/configure.ac
@@ -383,6 +383,8 @@ AC_CHECK_FUNCS([strndup strsep mmap strlcpy])
 AC_CHECK_FUNCS([getloadavg])
 AC_CHECK_FUNCS([getline])
 
+AC_CHECK_FUNCS([fstatat],[],[AC_MSG_WARN([fstatat() not available; distccd will be slightly less secure])])
+
 AC_CHECK_DECLS([snprintf, vsnprintf, vasprintf, asprintf, strndup])
 
 AC_MSG_CHECKING([if mmap() supports MAP_FAILED])

--- a/src/compile.c
+++ b/src/compile.c
@@ -446,6 +446,7 @@ static int dcc_please_send_email_after_investigation(
     return dcc_note_discrepancy(discrepancy_filename);
 }
 
+#ifdef HAVE_FSTATAT
 /* Re-write "cc" to directly call gcc or clang
  */
 static void dcc_rewrite_generic_compiler(char **argv)
@@ -517,6 +518,7 @@ static void dcc_rewrite_generic_compiler(char **argv)
     } else
         return;
 }
+#endif
 
 
 /* Clang is a native cross-compiler, but needs to be told to what target it is
@@ -682,7 +684,9 @@ dcc_build_somewhere(char *argv[],
     dcc_free_argv(argv);
     argv = new_argv;
     if (!getenv("DISTCC_NO_REWRITE_CROSS")) {
+#ifdef HAVE_FSTATAT
         dcc_rewrite_generic_compiler(new_argv);
+#endif
         dcc_add_clang_target(new_argv);
         dcc_gcc_rewrite_fqn(new_argv);
     }

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -160,13 +160,13 @@ static void dcc_warn_masquerade_whitelist(void) {
                        " --make-me-a-botnet. To set up masquerade automatically" \
                        " run update-distcc-symlinks.";
 
-    d = opendir("/usr/lib/distcc");
+    d = opendir(LIBDIR "/distcc");
     if (!d) {
-        rs_log_crit("/usr/lib/distcc not found. %s", warn);
+        rs_log_crit(LIBDIR "/distcc not found. %s", warn);
         dcc_exit(EXIT_COMPILER_MISSING);
     }
     if (!readdir(d)) {
-        rs_log_crit("/usr/lib/distcc empty. %s", warn);
+        rs_log_crit(LIBDIR "/distcc empty. %s", warn);
         dcc_exit(EXIT_COMPILER_MISSING);
     }
 }

--- a/src/dopt.c
+++ b/src/dopt.c
@@ -135,7 +135,7 @@ static const char *dcc_private_networks[] = {"192.168.0.0/16",
 
 const struct poptOption options[] = {
     { "allow", 'a',      POPT_ARG_STRING, 0, 'a', 0, 0 },
-    { "allow-private", 0,POPT_ARG_STRING, &opt_allow_private, 0, 0, 0 },
+    { "allow-private", 0,POPT_ARG_NONE, &opt_allow_private, 0, 0, 0 },
 #ifdef HAVE_GSSAPI
     { "auth", 0,	 POPT_ARG_NONE, &opt_auth_enabled, 'A', 0, 0 },
     { "blacklist", 0,    POPT_ARG_STRING, &arg_list_file, 'b', 0, 0 },

--- a/src/serve.c
+++ b/src/serve.c
@@ -376,7 +376,8 @@ static int dcc_check_compiler_whitelist(char *_compiler_name)
      * see https://github.com/distcc/distcc/issues/279
      */
     const char *creator_paths[] = { "/bin/", "/usr/bin/", NULL };
-    for (int i = 0 ; creator_paths[i] ; ++i) {
+    int i;
+    for (i = 0 ; creator_paths[i] ; ++i) {
         size_t len = strlen(creator_paths[i]);
         // /bin and /usr/bin are absolute paths (= compare from the string start)
         // use strncasecmp() to support case-insensitive / (= on Mac).

--- a/src/serve.c
+++ b/src/serve.c
@@ -370,6 +370,7 @@ static int dcc_check_compiler_masq(char *compiler_name)
  **/
 static int dcc_check_compiler_whitelist(char *_compiler_name)
 {
+#ifdef HAVE_FSTATAT
     char *compiler_name = _compiler_name;
     int dirfd = -1;
 
@@ -399,6 +400,7 @@ static int dcc_check_compiler_whitelist(char *_compiler_name)
     }
 
     rs_trace("%s in /usr/lib/distcc whitelist", compiler_name);
+#endif
     return 0;
 }
 

--- a/src/serve.c
+++ b/src/serve.c
@@ -358,7 +358,7 @@ static int dcc_check_compiler_masq(char *compiler_name)
 }
 
 /**
- * Make sure there is a masquerade to distcc in /usr/lib/distcc in order to
+ * Make sure there is a masquerade to distcc in LIBDIR/distcc in order to
  * execute a binary of the same name.
  *
  * Before this it was possible to execute arbitrary command after connecting
@@ -387,19 +387,19 @@ static int dcc_check_compiler_whitelist(char *_compiler_name)
         return EXIT_BAD_ARGUMENTS;
     }
 
-    dirfd = open("/usr/lib/distcc", O_RDONLY);
+    dirfd = open(LIBDIR "/distcc", O_RDONLY);
     if (dirfd < 0) {
         if (errno == ENOENT)
-            rs_log_crit("no %s", "/usr/lib/distcc");
+            rs_log_crit("no %s", LIBDIR "/distcc");
         return EXIT_DISTCC_FAILED;
     }
 
     if (faccessat(dirfd, compiler_name, X_OK, 0) < 0) {
-        rs_log_crit("%s not in %s whitelist.", compiler_name, "/usr/lib/distcc");
+        rs_log_crit("%s not in %s whitelist.", compiler_name, LIBDIR "/distcc");
         return EXIT_BAD_ARGUMENTS;           /* ENOENT, EACCESS, etc */
     }
 
-    rs_trace("%s in /usr/lib/distcc whitelist", compiler_name);
+    rs_trace("%s in" LIBDIR "/distcc whitelist", compiler_name);
 #endif
     return 0;
 }

--- a/src/zeroconf-reg.c
+++ b/src/zeroconf-reg.c
@@ -253,7 +253,7 @@ void* dcc_zeroconf_register(uint16_t port, int n_cpus, int n_jobs) {
     }
 
     if (!(ctx->client = avahi_client_new(avahi_threaded_poll_get(ctx->threaded_poll), AVAHI_CLIENT_NO_FAIL, client_callback, ctx, &error))) {
-        rs_log_crit("Failed to create client object: %s\n", avahi_strerror(avahi_client_errno(ctx->client)));
+        rs_log_crit("Failed to create client object: %s\n", avahi_strerror(error));
         goto fail;
     }
 


### PR DESCRIPTION
This PR contains 5 improvements and fixes (in 6 distinctive commits):

- prevent a nullptr dereference if Avahi client creation fails
- support systems that don't have fstatat() and family; provide a fallback compiler whitelist check
  that doesn't require faccesasat()
- the `--allow-private` option doesn't take an argument
- don't hardcode `/usr/lib/distcc` but `$PREFIX/distcc` instead
- fix  the QtCreator support workaround


The fstatat/faccessat chance was made in 2 commits; initially I thought it sufficient to skip the whitelisting feature on the concerned legacy systems but then I realised it was trivial to add an equivalent fallback implementation not using `faccessat()`. I didn't manage to squash the 2 commits without altering other commits.