### PR TITLE
compiler_masq: allow /usr/lib/distcc hardcoded

### DIFF
--- a/src/serve.c
+++ b/src/serve.c
@@ -414,8 +414,13 @@ static int dcc_check_compiler_whitelist(char *_compiler_name)
     int ret = 0;
     if (asprintf(&compiler_path, "%s/distcc/%s", LIBDIR, compiler_name) && compiler_path) {
         if (access(compiler_path, X_OK) < 0) {
-            rs_log_crit("%s not in %s whitelist.", compiler_name, LIBDIR "/distcc");
-            ret = EXIT_BAD_ARGUMENTS;           /* ENOENT, EACCESS, etc */
+            /* check /usr/lib/distcc too */
+            if (asprintf(&compiler_path, "/usr/lib/distcc/%s", compiler_name) && compiler_path) {
+                if (access(compiler_path, X_OK) < 0) {
+                    rs_log_crit("%s not in %s whitelist.", compiler_name, LIBDIR "/distcc");
+                    ret = EXIT_BAD_ARGUMENTS;           /* ENOENT, EACCESS, etc */
+                }
+            }
         }
         rs_trace("%s in" LIBDIR "/distcc whitelist", compiler_name);
     } else {


### PR DESCRIPTION
actually do this