### PR TITLE
global: add --enable-tcp-insecure in place of --make-me-a-botnet

### DIFF
--- a/man/distccd.1
+++ b/man/distccd.1
@@ -213,13 +213,11 @@ assumes daemon mode at startup if stdin is a tty, so
 starting distccd from a script or in a non-interactive
 ssh connection.
 .TP 
-.B --make-me-a-botnet
+.B --enable-tcp-insecure
 By default (since Distcc 3.3) distcc will only execute binaries
 that are masqueraded to distcc in /usr/lib/distcc. This turns
 that off, and opens distcc up to executing arbitrary code. This
-feature is mainly for distcc's test suite and is called
-.B --make-me-a-botnet
-for a reason. See MASQUERADING of
+feature is mainly for distcc's test suite. See MASQUERADING of
 .BR distcc (1).
 .TP 
 .B --zeroconf

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -157,7 +157,7 @@ static void dcc_warn_masquerade_whitelist(void) {
     DIR *d, *e;
     const char *warn = "You must see up masquerade" \
                        " (see distcc(1)) to list whitelisted compilers or pass" \
-                       " --make-me-a-botnet. To set up masquerade automatically" \
+                       " --enable-tcp-insecure. To set up masquerade automatically" \
                        " run update-distcc-symlinks.";
 
     e = opendir("/usr/lib/distcc");
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
     /* Initialize the distcc io timeout value */
     dcc_get_io_timeout();
 
-    if (!opt_make_me_a_botnet)
+    if (!opt_enable_tcp_insecure)
         dcc_warn_masquerade_whitelist();
 
     if (dcc_should_be_inetd())

--- a/src/dopt.c
+++ b/src/dopt.c
@@ -98,7 +98,7 @@ int opt_log_level_num = RS_LOG_NOTICE;
  * If true, do not check if a link to distcc exists in /usr/lib/distcc
  * for every program executed remotely.
  **/
-int opt_make_me_a_botnet = 0;
+int opt_enable_tcp_insecure = 0;
 
 /**
  * Daemon exits after this many seconds.  Intended mainly for testing, to make
@@ -171,7 +171,8 @@ const struct poptOption options[] = {
 #ifdef HAVE_AVAHI
     { "zeroconf", 0,     POPT_ARG_NONE, &opt_zeroconf, 0, 0, 0 },
 #endif
-    { "make-me-a-botnet", 0, POPT_ARG_NONE, &opt_make_me_a_botnet, 0, 0, 0 },
+    { "make-me-a-botnet", 0, POPT_ARG_NONE, &opt_enable_tcp_insecure, 0, 0, 0 },
+    { "enable-tcp-insecure", 0, POPT_ARG_NONE, &opt_enable_tcp_insecure, 0, 0, 0 },
     { 0, 0, 0, 0, 0, 0, 0 }
 };
 

--- a/src/dopt.h
+++ b/src/dopt.h
@@ -37,7 +37,7 @@ extern int opt_no_fork;
 extern int opt_no_prefork;
 extern int opt_no_detach;
 extern int opt_daemon_mode, opt_inetd_mode;
-extern int opt_make_me_a_botnet;
+extern int opt_enable_tcp_insecure;
 extern int opt_job_lifetime;
 extern const char *arg_log_file;
 extern int opt_no_fifo;

--- a/src/serve.c
+++ b/src/serve.c
@@ -389,7 +389,7 @@ static int dcc_check_compiler_whitelist(char *_compiler_name)
     }
 
     if (strchr(compiler_name, '/')) {
-        rs_log_crit("compiler name <%s> cannot be an absolute path (or must set DISTCC_CMDLIST or pass --make-me-a-botnet)", _compiler_name);
+        rs_log_crit("compiler name <%s> cannot be an absolute path (or must set DISTCC_CMDLIST or pass --enable-tcp-insecure)", _compiler_name);
         return EXIT_BAD_ARGUMENTS;
     }
 
@@ -751,7 +751,7 @@ static int dcc_run_job(int in_fd,
     if ((ret = dcc_check_compiler_masq(argv[0])))
         goto out_cleanup;
 
-    if (!opt_make_me_a_botnet &&
+    if (!opt_enable_tcp_insecure &&
         !getenv("DISTCC_CMDLIST") &&
         dcc_check_compiler_whitelist(argv[0]))
         goto out_cleanup;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -236,7 +236,7 @@ int dcc_ssh_connect(char *ssh_cmd,
     child_argv[i++] = machine;
     child_argv[i++] = path;
     child_argv[i++] = (char *) "--inetd";
-    child_argv[i++] = (char *) "--make-me-a-botnet";
+    child_argv[i++] = (char *) "--enable-tcp-insecure";
     child_argv[i++] = NULL;
 
     rs_trace("connecting to %s using %s", machine, ssh_cmd);

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -345,7 +345,7 @@ as soon as that happens we can go ahead and start the client."""
         """Return command to start the daemon"""
         return (self.distccd() +
                 "--verbose --lifetime=%d --daemon --log-file %s "
-                "--pid-file %s --port %d --allow 127.0.0.1 --make-me-a-botnet"
+                "--pid-file %s --port %d --allow 127.0.0.1 --enable-tcp-insecure"
                 % (self.daemon_lifetime(),
                    _ShellSafe(self.daemon_logfile),
                    _ShellSafe(self.daemon_pidfile),
@@ -815,7 +815,7 @@ class DaemonBadPort_Case(SimpleDistCC_Case):
         """Test daemon invoked with invalid port number"""
         self.runcmd(self.distccd() +
                     "--log-file=distccd.log --lifetime=10 --port 80000 "
-                    "--allow 127.0.0.1 --make-me-a-botnet",
+                    "--allow 127.0.0.1 --enable-tcp-insecure",
                     EXIT_BAD_ARGUMENTS)
         self.assert_no_file("daemonpid.tmp")
 
@@ -1546,7 +1546,7 @@ class NoDetachDaemon_Case(CompileHello_Case):
         # port as an existing server, because we can't catch the error.
         cmd = (self.distccd() +
                "--no-detach --daemon --verbose --log-file %s --pid-file %s "
-               "--port %d --allow 127.0.0.1 --make-me-a-botnet" %
+               "--port %d --allow 127.0.0.1 --enable-tcp-insecure" %
                (_ShellSafe(self.daemon_logfile),
                 _ShellSafe(self.daemon_pidfile),
                 self.server_port))
@@ -2046,7 +2046,7 @@ class AccessDenied_Case(CompileHello_Case):
     def daemon_command(self):
         return (self.distccd()
                 + "--verbose --lifetime=%d --daemon --log-file %s "
-                  "--pid-file %s --port %d --allow 127.0.0.2 --make-me-a-botnet"
+                  "--pid-file %s --port %d --allow 127.0.0.2 --enable-tcp-insecure"
                 % (self.daemon_lifetime(),
                    _ShellSafe(self.daemon_logfile),
                    _ShellSafe(self.daemon_pidfile),


### PR DESCRIPTION
As discussed in bug #155, --make-me-a-botnet was not self-descriptive enough.