### PR TITLE
Include netinet/in.h in src/util.c for sockaddr_in structure

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -39,6 +39,8 @@
 #include <sys/un.h>
 #include <sys/socket.h>
 
+#include <netinet/in.h>
+
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif


### PR DESCRIPTION
This fixes building on FreeBSD.