### PR TITLE
add some more GCC args that indicate profiling

### DIFF
--- a/src/arg.c
+++ b/src/arg.c
@@ -206,8 +206,12 @@ int dcc_scan_args(char *argv[], char **input_file, char **output_file,
                 seen_opt_s = 1;
             } else if (!strcmp(a, "-fprofile-arcs")
                        || !strcmp(a, "-ftest-coverage")
-		       || !strcmp(a, "--coverage")) {
-                rs_log_info("compiler will emit profile info; must be local");
+		       || !strcmp(a, "--coverage")
+		       || !strncmp(a, "-fprofile-generate", 18) /* it also has an -fprofile-generate=<path> form */
+		       || !strncmp(a, "-fprofile-use", 13)
+		       || !strncmp(a, "-fauto-profile", 14)
+		       || !strcmp(a, "-fprofile-correction")) {
+                rs_log_info("compiler will emit/use profile info; must be local");
                 return EXIT_DISTCC_FAILED;
             } else if (!strcmp(a, "-frepo")) {
                 rs_log_info("compiler will emit .rpo files; must be local");


### PR DESCRIPTION
Relevant documentation:
https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

Also relevant is the need to avoid remote compilation when the compiler
might try to use a .gcda file generated locally during a profiling run
(common occurrence during profile-guided optimisation).