### PR TITLE
Update homepage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 by Martin Pool
 
-Current Documents: https://cdn.rawgit.com/distcc/distcc/9a09372bd3f420cdd7021e52eda14fa536a3c10e/doc/web/index.html
+Current Documents: https://distcc.github.io/
 Formally http://distcc.org/
 
 "pump" functionality added by


### PR DESCRIPTION
Link to github.io instead of the rawgit CDN backend.

rawgit is sunsetting.