### PR TITLE
Handle complex arguments, like assembler macros

### DIFF
--- a/include_server/parse_command_test.py
+++ b/include_server/parse_command_test.py
@@ -133,6 +133,10 @@ class ParseCommandUnitTest(unittest.TestCase):
           + " -isystem system -Imice -iquote/and -I/men a.c "
           + " -include included_A.h "
           + " -includeincluded_B.h "
+          + " -Wa,macros_A.s "
+          + " -Wa,[macros_B.s] "
+          + " -Wa,arch/x86/kernel/macros.s -Wa,- "
+          + " -Wa,other_directive "
           + "-Xlinker W,l -L /ignored_by_us -o a.o"),
           os.getcwd(),
           self.includepath_map,
@@ -146,7 +150,8 @@ class ParseCommandUnitTest(unittest.TestCase):
        filepath),
       (('/and', 'mice', '/men', 'system'),
        ('mice', '/men', 'system'),
-       ["included_A.h", "included_B.h"],
+       ["included_A.h", "included_B.h",
+        "macros_A.s", "macros_B.s", "arch/x86/kernel/macros.s"],
        'a.c'))
 
 


### PR DESCRIPTION
The Linux kernel has started using statements like
-Wa,macros.s for including assembler with the code.

Handle these similar to the `-imacros` statement,
and send them to the compile server for processing.

Closes #312 