### PR TITLE
When waiting for the wrapped process to exit, make sure it's not a zombie

### DIFF
--- a/pump.in
+++ b/pump.in
@@ -366,7 +366,11 @@ ShutDown() {
     # Note that while 'sleep 0.01' is relying on a feature of GNU sleep,
     # that's OK; on systems that don't support it, it's effectively the
     # same as 'sleep 0', i.e. we'll just busy-wait rather than sleeping.
-    while kill -0 $include_server_pid; do sleep 0.01; done >/dev/null 2>&1
+    # check if the process still exists AND if the state of it is not zombie. If it is a zombie,
+    # this loop would deadlock, because the zombie process would only be reaped when this script exits
+    # and this script only exits if the zombie process would be terminated.
+    while kill -0 "$include_server_pid" && [ "$(ps --no-headers -o state \
+      p $include_server_pid)x" != "Zx" ]; do sleep 0.01; done >/dev/null 2>&1
   fi
 
   if [ -f "$include_server_stdout" ]; then


### PR DESCRIPTION
Makes pump work inside docker when used by my docker-makepkg script. Otherwise it deadlocks.
The patch does exactly what is described in the comment.