### PR TITLE
Remove Martin Pool's Email Address From AUTHORS File

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 Author and maintainer emeritus of distcc:
  
-  Martin Pool <mbp@sourcefrog.net>
+  Martin Pool
 
 Authors of "pump" functionality, and maintainers of distcc:
 


### PR DESCRIPTION
After being contacted by a user looking for Help, it was stated under #326 that Martin Pool thought it best that his email address be removed from the AUTHORS file.  Martin has not worked on distcc for over a decade, so is no longer in a position to provide much support to users.