### PR TITLE
Fix possible memory leak

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -594,7 +594,7 @@ static int dcc_gcc_rewrite_fqn(char **argv)
             t = path + strlen(path);
         pathlen = t - path;
         if (*path == '\0')
-            return -ENOENT;
+            break;
         strncpy(binname, path, pathlen);
         binname[pathlen] = '\0';
         strcat(binname, "/");
@@ -609,6 +609,7 @@ static int dcc_gcc_rewrite_fqn(char **argv)
         argv[0] = newcmd;
         return 0;
     } while ((path += pathlen + 1));
+    free(newcmd);
     return -ENOENT;
 }
 


### PR DESCRIPTION
Memory leak was detected by https://www.viva64.com/pvs-studio/

 V773 The function was exited without releasing the 'newcmd' pointer.
 A memory leak is possible.

Signed-off-by: Oleh Kravchenko <oleg@kaa.org.ua>