### PR TITLE
Fix memory leaks detected by PVS-Studio

### DIFF
--- a/src/argutil.c
+++ b/src/argutil.c
@@ -95,7 +95,7 @@ void dcc_free_argv(char **argv)
 int dcc_copy_argv(char **from, char ***out, int delta)
 {
     char **b;
-    int l, i;
+    int l, i, k;
 
     l = dcc_argv_len(from);
     b = malloc((l+1+delta) * (sizeof from[0]));
@@ -106,6 +106,9 @@ int dcc_copy_argv(char **from, char ***out, int delta)
     for (i = 0; i < l; i++) {
         if ((b[i] = strdup(from[i])) == NULL) {
             rs_log_error("failed to duplicate element %d", i);
+            for(k = 0; k < i; k++)
+                free(b[k]);
+            free(b);
             return EXIT_OUT_OF_MEMORY;
         }
     }

--- a/src/climasq.c
+++ b/src/climasq.c
@@ -117,8 +117,10 @@ int dcc_support_masquerade(char *argv[], char *progname, int *did_masquerade)
 
     if (*p != '\0') {
         int ret = dcc_set_path(p);
-        if (ret)
+        if (ret) {
+            free(buf);
             return ret;
+        }
         *did_masquerade = 1;
     }
     else {

--- a/src/stringmap.c
+++ b/src/stringmap.c
@@ -43,14 +43,20 @@
  */
 stringmap_t *stringmap_load(const char *filename, int numFinalWordsToMatch)
 {
-    stringmap_t *result = calloc(1, sizeof(*result));
-    FILE *fp = fopen(filename, "r");
+    stringmap_t *result;
+    FILE *fp;
     char buf[2*PATH_MAX];
     int n;
 
-    result->numFinalWordsToMatch = numFinalWordsToMatch;
-    if (!fp)
+    result = calloc(1, sizeof(*result));
+    if (!result)
         return NULL;
+    result->numFinalWordsToMatch = numFinalWordsToMatch;
+    fp = fopen(filename, "r");
+    if (!fp) {
+        free(result);
+        return NULL;
+    }
     n=0;
     while (fgets(buf, sizeof(buf), fp))
         n++;

--- a/src/util.c
+++ b/src/util.c
@@ -580,7 +580,7 @@ int dcc_remove_if_exists(const char *fname)
 
 int dcc_which(const char *command, char **out)
 {
-    char *loc = NULL, *path, *t;
+    char *loc = NULL, *_loc, *path, *t;
     int ret;
 
     path = getenv("PATH");
@@ -593,9 +593,12 @@ int dcc_which(const char *command, char **out)
         t = strchr(path, ':');
         if (!t)
             t = path + strlen(path);
-        loc = realloc(loc, t - path + 1 + strlen(command) + 1);
-        if (!loc)
+        _loc = realloc(loc, t - path + 1 + strlen(command) + 1);
+        if (!_loc) {
+            free(loc);
             return -ENOMEM;
+        }
+        loc = _loc;
         strncpy(loc, path, t - path);
         loc[t - path] = '\0';
         strcat(loc, "/");


### PR DESCRIPTION
- climasq.c:121 The function was exited without releasing the 'buf' pointer.
- argutil.c:109 The function was exited without releasing the 'b' pointer.
- stringmap.c:53 The function was exited without releasing the 'result' pointer.
- util.c:596 when realloc() fails in allocating memory,
  original pointer 'loc' is lost.

Signed-off-by: Oleh Kravchenko <oleg@kaa.org.ua>