### PR TITLE
Update to new ccache URL

### DIFF
--- a/doc/web/benchmark.html
+++ b/doc/web/benchmark.html
@@ -35,7 +35,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 	  </ul>

--- a/doc/web/compared.html
+++ b/doc/web/compared.html
@@ -47,7 +47,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 	  </ul>

--- a/doc/web/compilers.html
+++ b/doc/web/compilers.html
@@ -47,7 +47,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 </ul>

--- a/doc/web/distcc-lca-2004.html
+++ b/doc/web/distcc-lca-2004.html
@@ -114,7 +114,7 @@ file.</li>
 preprocessed text plus the compiler command line completely specifies
 the output.  By running the preprocessor locally, distcc avoids any
 requirement to have the same headers on all machines.</p>
-<p>Before distcc, the <a class="reference" href="http://www.erikyyy.de/compilercache/">compilercache</a> and <a class="reference" href="http://ccache.samba.org/">ccache</a> programs used this
+<p>Before distcc, the <a class="reference" href="http://www.erikyyy.de/compilercache/">compilercache</a> and <a class="reference" href="https://ccache.dev/">ccache</a> programs used this
 observation to remember the results of building a particular source
 file.  This can be useful when trees are cleaned and rebuilt, or when
 similar trees are built in different directories.</p>

--- a/doc/web/faq.html
+++ b/doc/web/faq.html
@@ -44,7 +44,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 	  </ul>
@@ -737,7 +737,7 @@ a kernel bug.
 <p>
   Programs that use gcc's <a href="http://lists.samba.org/pipermail/distcc/2003q3/001547.html">DEPENDENCIES_OUTPUT</a> option don't work with ccache.
 <p>
-  This should be fixed in <a href="http://ccache.samba.org/">ccache 2.3</a>.  There is no problem with distcc.
+  This should be fixed in <a href="https://ccache.dev/">ccache 2.3</a>.  There is no problem with distcc.
 
 
 <h3>distcc fails to build on OS X</h3>
@@ -816,7 +816,7 @@ This is Debian <a href="http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=148957&
 This can affect other programs which rely on debug stabs, such as 
 <tt>addr2line</tt>, and it results in object files not being
 byte-for-byte identical when they include the source directory.  The
-same bug affects <a href="http://ccache.samba.org/">ccache</a>.
+same bug affects <a href="https://ccache.dev/">ccache</a>.
 
 <h3>TCP_CORK in linux-2.2</h3> 
 <p>

--- a/doc/web/index.html
+++ b/doc/web/index.html
@@ -34,7 +34,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 	  </ul>
@@ -159,7 +159,7 @@ For more detailed installation instructions, see the
 
      <ul>
        <li>
-         <a href="http://ccache.samba.org/">ccache</a>
+         <a href="https://ccache.dev/">ccache</a>
 	 caches compiler output to accelerate builds.
       <li>
        <a href="http://dmucs.sourceforge.net/">dmucs</a> helps distcc select

--- a/doc/web/man/distcc_1.html
+++ b/doc/web/man/distcc_1.html
@@ -1291,6 +1291,6 @@ SEE ALSO</A>
 </H2>
 <B>distccd</B>(1), <B>pump</B>(1), <B>include_server</B>(1), <B>gcc</B>(1),
 <B>make</B>(1), and  <B>ccache</B>(1). <I> http://code.google.com/p/distcc/</I>
-<I>http://ccache.samba.org/</I><BR>
+<I>https://ccache.dev/</I><BR>
 </BODY>
 </HTML>

--- a/doc/web/man/distccmon_text_1.html
+++ b/doc/web/man/distccmon_text_1.html
@@ -156,6 +156,6 @@ SEE ALSO</A>
 <BR>
 <P>
 distccd(1), ccache(1), gcc(1), make(1) http://code.google.com/p/distcc/
-http://ccache.samba.org/<BR>
+https://ccache.dev/<BR>
 </BODY>
 </HTML>

--- a/doc/web/man/include_server_1.html
+++ b/doc/web/man/include_server_1.html
@@ -493,6 +493,6 @@ COPYING.<BR>
 SEE ALSO</A>
 </H2>
 <B>distcc</B>(1), <B>distccd</B>(1), <B>include_server</B>(1),
-and <B>gcc</B>(1). http://code.google.com/p/distcc/ http://ccache.samba.org/<BR>
+and <B>gcc</B>(1). http://code.google.com/p/distcc/ https://ccache.dev/<BR>
 </BODY>
 </HTML>

--- a/doc/web/results.html
+++ b/doc/web/results.html
@@ -44,7 +44,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 	  </ul>
@@ -64,7 +64,7 @@ For speeding up our builds we use and
       be set up in no time and if like us you're continuously and
       repeatedly building lots of code it'll save you hours if not
       days of waiting around for compiles to finish. Also check out
-      <a href="http://ccache.samba.org/">ccache</a>.
+      <a href="https://ccache.dev/">ccache</a>.
         &mdash; The 
 <a href=http://www.rosegardenmusic.com/resources/links/>Rosegarden</a>
 music software developers.

--- a/doc/web/scenarios.html
+++ b/doc/web/scenarios.html
@@ -44,7 +44,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 	  </ul>

--- a/doc/web/security.html
+++ b/doc/web/security.html
@@ -44,7 +44,7 @@
 	  <ul>
 	      <li><a title="How to use distcc and Gentoo" href="http://www.gentoo.org/doc/en/distcc.xml">Gentoo</a></li>
 	      <li><a title="Script to ease building cross-compilers and toolchains" href="http://kegel.com/crosstool/">crosstool</a></li>
-	      <li><a title="Cache compiler results" href="http://ccache.samba.org/">ccache</a></li>
+	      <li><a title="Cache compiler results" href="https://ccache.dev/">ccache</a></li>
 	      <li><a title="Centralized control over distcc and ccache" href="http://ccontrol.ozlabs.org/">ccontrol</a></li>
 	      <li><a title="Smart job scheduler" href="http://dmucs.sourceforge.net/">dmucs</a></li>
 	  </ul>

--- a/man/distcc.1
+++ b/man/distcc.1
@@ -985,4 +985,4 @@ COPYING.
 \fBdistccd\fR(1), \fBpump\fR(1), \fBinclude_server\fR(1), \fBgcc\fR(1),
 \fBmake\fR(1), and  \fBccache\fR(1).
 .I http://code.google.com/p/distcc/
-.I http://ccache.samba.org/
+.I https://ccache.dev/

--- a/man/distccmon-text.1
+++ b/man/distccmon-text.1
@@ -55,4 +55,4 @@ distcc  was  written  by Martin Pool <mbp@sourcefrog.net>, with the co\-operatio
 .LP d
 distccd(1), ccache(1), gcc(1), make(1)
 http://code.google.com/p/distcc/
-http://ccache.samba.org/
+https://ccache.dev/

--- a/man/include_server.1
+++ b/man/include_server.1
@@ -303,4 +303,4 @@ COPYING.
 
 .SH "SEE ALSO"
 \fBdistcc\fR(1), \fBdistccd\fR(1), \fBinclude_server\fR(1), and \fBgcc\fR(1).
-http://code.google.com/p/distcc/ http://ccache.samba.org/
+http://code.google.com/p/distcc/ https://ccache.dev/


### PR DESCRIPTION
ccache’s web site is now located at https://ccache.dev.