### PR TITLE
Fix installing pump on FreeBSD with ports

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1098,7 +1098,7 @@ install-include-server: include-server pump
 	  INCLUDE_SERVER=`grep '/include_server.py$$' "$(include_server_builddir)/install.log"` && \
 	  sed "s,^include_server='',include_server='$$INCLUDE_SERVER'," \
 	    pump > "$(include_server_builddir)/pump" && \
-	  $(INSTALL_PROGRAM) "$(include_server_builddir)/pump" "$(DESTDIR)$(bindir)"; \
+	  $(INSTALL_SCRIPT) "$(include_server_builddir)/pump" "$(DESTDIR)$(bindir)"; \
 	fi
 
 install-man: $(man1_MEN)


### PR DESCRIPTION
The FreeBSD ports system attempts to strip binaries installed with
`INSTALL_PROGRAM`, which unfortunately never works with scripts like
`pump`. Install `pump` with `INSTALL_SCRIPT` instead so the script is
installed with `install ..` instead of `install -s ..`.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>