### PR TITLE
Fix `make check` when pump support is not installed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -777,12 +777,9 @@ maintainer-check: distcc-maintainer-check include-server-maintainer-check \
 check:
 	@if test -n "$(PYTHON)"; then \
 	   $(MAKE) maintainer-check; \
-	elif test -n "$(PYTHON)"; then \
+	else \
 	   echo "WARNING: pump-mode not being tested"; \
 	   $(MAKE) distcc-maintainer-check; \
-	else \
-	   echo "Cannot run tests: python binary not found"; \
-	   false; \
 	fi
 
 # Runs the tests in lzo-mode.


### PR DESCRIPTION
pump support is the only thing (currently) that requires python support
in order to be built/tested. Don't predicate all testing on whether or
not PYTHON is available/specified.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>