### PR TITLE
Makefile.in: fix out-of-tree builds when the GNOME UI is enabled

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1130,8 +1130,8 @@ install-example: $(example_DOCS)
 install-gnome-data: $(gnome_data)
 	$(mkinstalldirs) "$(DESTDIR)$(icondir)"
 	$(mkinstalldirs) "$(DESTDIR)$(desktopdir)"
-	$(INSTALL_DATA) gnome/distccmon-gnome.png "$(DESTDIR)$(icondir)"
-	$(INSTALL_DATA) gnome/distccmon-gnome.desktop "$(DESTDIR)$(desktopdir)"
+	$(INSTALL_DATA) $(srcdir)/gnome/distccmon-gnome.png "$(DESTDIR)$(icondir)"
+	$(INSTALL_DATA) $(srcdir)/gnome/distccmon-gnome.desktop "$(DESTDIR)$(desktopdir)"
 
 install-conf: $(conf_files) $(default_files)
 	$(mkinstalldirs) "$(DESTDIR)$(sysconfdir)/distcc"


### PR DESCRIPTION
The install command doesn't use $(srcdir) so out-of-tree builds fail.

Signed-off-by: Ross Burton <ross.burton@intel.com>