### PR TITLE
Allow daemon DNS lookup of allowed hostnames

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -183,7 +183,7 @@ int dcc_parse_mask(const char *spec,
 #else /* ENABLE_RFC2553 */
 
     memset(&hints, 0, sizeof(hints));
-    hints.ai_flags = AI_NUMERICHOST;
+    hints.ai_flags = 0;
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 


### PR DESCRIPTION
Removed the flag that only allows numeric IP addresses for the allowed clients. DNS lookup will only be performed if configured with --enable-rfc2553.

DNS lookup only happens at daemon start.

Issue #366 