### PR TITLE
#370 Replace time.clock() with time.perf_counter()

### DIFF
--- a/include_server/parse_file.py
+++ b/include_server/parse_file.py
@@ -272,7 +272,7 @@ class ParseFile(object):
 
     assert isinstance(filepath, str)
     self.filepath = filepath
-    parse_file_start_time = time.clock()
+    parse_file_start_time = time.perf_counter()
     statistics.parse_file_counter += 1
 
     includepath_map_index = self.includepath_map.Index
@@ -338,6 +338,6 @@ class ParseFile(object):
                       expr_includes, next_includes)
 
 
-    statistics.parse_file_total_time += time.clock() - parse_file_start_time
+    statistics.parse_file_total_time += time.perf_counter() - parse_file_start_time
 
     return (quote_includes, angle_includes, expr_includes, next_includes)

--- a/include_server/statistics.py
+++ b/include_server/statistics.py
@@ -62,13 +62,13 @@ def StartTiming():
   global start_time, translation_unit_counter
   """Mark the start of a request to find an include closure."""
   translation_unit_counter += 1
-  start_time = time.clock()
+  start_time = time.perf_counter()
 
 
 def EndTiming():
   """Mark the end of an include closure calculation."""
   global translation_unit_time, min_time, max_time, total_time
-  translation_unit_time = time.clock() - start_time
+  translation_unit_time = time.perf_counter() - start_time
   min_time = min(translation_unit_time, min_time)
   max_time = max(translation_unit_time, max_time)
   total_time += translation_unit_time


### PR DESCRIPTION
.clock() got removed in python 3.8 and was marked as deprecated since 3.3
(https://github.com/python/cpython/pull/13270)

refers to https://github.com/distcc/distcc/issues/370