### PR TITLE
Fix build with gcc 10 which defaults to -fno-common (cf https://gcc.g…

### DIFF
--- a/src/stats.h
+++ b/src/stats.h
@@ -33,7 +33,7 @@ enum stats_e { STATS_TCP_ACCEPT, STATS_REJ_BAD_REQ, STATS_REJ_OVERLOAD,
                 STATS_COMPILE_OK, STATS_COMPILE_ERROR, STATS_COMPILE_TIMEOUT,
                 STATS_CLI_DISCONN, STATS_OTHER, STATS_ENUM_MAX };
 
-const char *stats_text[20];
+extern const char *stats_text[20];
 
 int  dcc_stats_init(void);
 void dcc_stats_init_kid(void);


### PR DESCRIPTION
…nu.org/gcc-10/porting_to.html)

This fixes the following link error I see when I use the latest gcc 10
git branch:
/opt/1A/toolchain/x86_64-v20.0.7/lib/gcc/x86_64-1a-linux-gnu/10.0.1/../../../../x86_64-1a-linux-gnu/bin/ld: src/serve.o:(.bss+0x0): multiple definition of `stats_text'; src/prefork.o:(.bss+0x0): first defined here
/opt/1A/toolchain/x86_64-v20.0.7/lib/gcc/x86_64-1a-linux-gnu/10.0.1/../../../../x86_64-1a-linux-gnu/bin/ld: src/stats.o:(.data+0x20): multiple definition of `stats_text'; src/prefork.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status