### PR TITLE
Bring back OSX to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,6 @@ matrix:
   - os: linux
     compiler: clang
     dist: trusty
+  - os: osx
+    osx_image: xcode9
+    compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
       - libavahi-client-dev 
 
 before_install:
+  # Work around https://github.com/Homebrew/brew/issues/7356
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export HOMEBREW_NO_INSTALL_CLEANUP=1; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python; fi
 


### PR DESCRIPTION
I think the thing that was happening is related to https://github.com/Homebrew/brew/issues/7360 and https://github.com/Homebrew/brew/issues/7356.

It'd be a shame if OSX builds started failing in a deeper way because of bit-rot while not testing on CI.