### PR TITLE
tempfile: Fix build on Cygwin/MSYS2

### DIFF
--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -52,6 +52,7 @@
 
 #ifdef __CYGWIN32__
     #define NOGDI
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
 #endif
 


### PR DESCRIPTION
src is in the include paths (the Makefile has -Isrc), and it contains
rpc.h, which collides with an internal header with the same name inside
/usr/include/w32api. This leads to compiler errors.

Fix by defining `WIN32_LEAN_AND_MEAN`, which prevents inclusion of rpc stuff.