### PR TITLE
Fix GCC warning

### DIFF
--- a/include_server/c_extensions/distcc_pump_c_extensions_module.c
+++ b/include_server/c_extensions/distcc_pump_c_extensions_module.c
@@ -211,7 +211,7 @@ XArgv(PyObject *dummy, PyObject *args) {
     PyObject *string_object;
     string_object = PyList_GetItem(list_object, i); /* borrowed ref */
 /* TODO do it properly, catch exceptions for fancy Unicode symbols */
-    argv[i] = PyUnicode_AsUTF8(string_object);    /* does not increase
+    argv[i] = (char*)PyUnicode_AsUTF8(string_object); /* does not increase
                                                      ref count */
   }
   ret = dcc_x_argv(ifd, "ARGC", "ARGV", argv);


### PR DESCRIPTION
```
include_server/c_extensions/distcc_pump_c_extensions_module.c: In function ‘XArgv’:
include_server/c_extensions/distcc_pump_c_extensions_module.c:214:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  214 |     argv[i] = PyUnicode_AsUTF8(string_object);    /* does not increase
      |             ^
```

Far from optimal, but fixing const-correctness will require many changes.