### PR TITLE
Fix memory and file descriptor leaks

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -170,6 +170,12 @@ static void dcc_warn_masquerade_whitelist(void) {
         rs_log_crit(LIBDIR "/distcc empty. %s", warn);
         dcc_exit(EXIT_COMPILER_MISSING);
     }
+    if (d) {
+        closedir(d);
+    }
+    if (e) {
+        closedir(e);
+    }
 }
 
 /**

--- a/src/serve.c
+++ b/src/serve.c
@@ -405,12 +405,15 @@ static int dcc_check_compiler_whitelist(char *_compiler_name)
         char *compiler_path = NULL;
         if (asprintf(&compiler_path, "/usr/lib/distcc/%s", compiler_name) && compiler_path) {
             if (access(compiler_path, X_OK) < 0) {
+                close(dirfd);
                 rs_log_crit("%s not in %s or %s whitelist.", compiler_name, LIBDIR "/distcc", "/usr/lib/distcc");
                 return EXIT_BAD_ARGUMENTS;           /* ENOENT, EACCESS, etc */
             }
             free(compiler_path);
         }
     }
+
+    close(dirfd);
 
     rs_trace("%s in" LIBDIR "/distcc whitelist", compiler_name);
     return 0;


### PR DESCRIPTION
distcc leaks memory and file descriptor during checks for the compiler whitelist.