### PR TITLE
Port distccmon-gnome from gtk2 to gtk3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,10 +132,10 @@ AC_ARG_ENABLE(Werror,
 # we need.  It's faster to just do it once during configuration.
 if test "x${with_gnome}" = xyes
 then
-    GNOME_PACKAGES="gtk+-2.0 libgnome-2.0 libgnomeui-2.0 pango"
+    GNOME_PACKAGES="gtk+-3.0 libgnome-3.0 libgnomeui-3.0 pango"
 elif test "x${with_gtk}" = xyes
 then
-    GNOME_PACKAGES="gtk+-2.0"
+    GNOME_PACKAGES="gtk+-3.0"
 else
     GNOME_PACKAGES=""
 fi

--- a/src/mon-gnome.c
+++ b/src/mon-gnome.c
@@ -97,15 +97,6 @@ enum {
 };
 
 
-/**
- * Graphics contexts to be used to draw each particular state into the
- * model.
- **/
-//GdkGC *dcc_phase_gc[DCC_PHASE_DONE];
-//TODO rename _gc to _cr
-cairo_t *dcc_phase_gc[DCC_PHASE_DONE];
-
-
 #if 0
 /* shades of red */
 const GdkColor task_color[] = {

--- a/src/mon-gnome.c
+++ b/src/mon-gnome.c
@@ -528,6 +528,8 @@ static GtkWidget * dcc_gnome_make_load_bar (void)
   gint context_id;
 
   bar = gtk_statusbar_new ();
+  gtk_widget_set_margin_top(GTK_WIDGET(bar), 0);
+  gtk_widget_set_margin_bottom(GTK_WIDGET(bar), 0);
   context_id = gtk_statusbar_get_context_id(GTK_STATUSBAR (bar), "load");
 
   gtk_statusbar_push(GTK_STATUSBAR (bar), context_id, "Load: ");

--- a/src/mon-gnome.c
+++ b/src/mon-gnome.c
@@ -101,7 +101,9 @@ enum {
  * Graphics contexts to be used to draw each particular state into the
  * model.
  **/
-GdkGC *dcc_phase_gc[DCC_PHASE_DONE];
+//GdkGC *dcc_phase_gc[DCC_PHASE_DONE];
+//TODO rename _gc to _cr
+cairo_t *dcc_phase_gc[DCC_PHASE_DONE];
 
 
 #if 0
@@ -453,7 +455,7 @@ static void
 dcc_create_state_gcs (GtkWidget *widget)
 {
   enum dcc_phase i_state;
-
+#if 0
   for (i_state = 0; i_state < DCC_PHASE_DONE; i_state++)
     {
       dcc_phase_gc[i_state] = gdk_gc_new (widget->window);
@@ -461,6 +463,16 @@ dcc_create_state_gcs (GtkWidget *widget)
                                (GdkColor *) &task_color[i_state]);
 
     }
+#else
+  for (i_state = 0; i_state < DCC_PHASE_DONE; i_state++)
+    {
+      GdkWindow * gdk_window = gtk_widget_get_window (widget);
+      dcc_phase_gc[i_state] = gdk_cairo_create(gdk_window);
+      gdk_cairo_set_source_color (dcc_phase_gc[i_state],
+                               (GdkColor *) &task_color[i_state]);
+
+    }
+#endif
 }
 
 
@@ -477,7 +489,7 @@ static void dcc_gnome_make_proc_view (GtkTreeModel *proc_model,
   GtkWidget *align, *proc_scroll;
 
   chart_treeview = gtk_tree_view_new_with_model (proc_model);
-  gtk_object_set (GTK_OBJECT (chart_treeview),
+  g_object_set (G_OBJECT (chart_treeview),
                   "headers-visible", TRUE,
                   NULL);
 
@@ -592,9 +604,9 @@ static GtkWidget * dcc_gnome_make_mainwin (void)
   gtk_window_set_default_size (GTK_WINDOW (mainwin), 500, 300);
 
   /* Quit when it's closed */
-  g_signal_connect (GTK_OBJECT(mainwin), "delete-event",
+  g_signal_connect (G_OBJECT(mainwin), "delete-event",
                     G_CALLBACK (gtk_main_quit), NULL);
-  g_signal_connect (GTK_OBJECT(mainwin), "destroy",
+  g_signal_connect (G_OBJECT(mainwin), "destroy",
                     G_CALLBACK (gtk_main_quit), NULL);
 
 #if GTK_CHECK_VERSION(2,2,0)

--- a/src/mon-gnome.c
+++ b/src/mon-gnome.c
@@ -443,12 +443,12 @@ static gint dcc_gnome_load_update_cb (gpointer data)
  * renderers, and a data model.
  **/
 static void dcc_gnome_make_proc_view (GtkTreeModel *proc_model,
-                                      GtkWidget **align_return)
+                                      GtkWidget **widget_return)
 {
   GtkCellRenderer *text_renderer, *chart_renderer;
   GtkTreeSelection *selection;
   GtkTreeViewColumn *column;
-  GtkWidget *align, *proc_scroll;
+  GtkWidget *proc_scroll;
 
   chart_treeview = gtk_tree_view_new_with_model (proc_model);
   g_object_set (G_OBJECT (chart_treeview),
@@ -514,11 +514,7 @@ static void dcc_gnome_make_proc_view (GtkTreeModel *proc_model,
                                   GTK_POLICY_AUTOMATIC);
   gtk_container_add (GTK_CONTAINER (proc_scroll), chart_treeview);
 
-  /* Expands to fill all space */
-  align = gtk_alignment_new (0.0, 0.0, 1.0, 1.0);
-  gtk_container_add (GTK_CONTAINER (align), proc_scroll);
-
-  *align_return = align;
+  *widget_return = proc_scroll;
 }
 
 

--- a/src/mon-gnome.c
+++ b/src/mon-gnome.c
@@ -97,36 +97,38 @@ enum {
 };
 
 
-#if 0
-/* shades of red */
-const GdkColor task_color[] = {
-  { 0, 0x2222, 0, 0 },          /* DCC_PHASE_STARTUP, */
-  { 0, 0x4444, 0, 0 },          /* DCC_PHASE_BLOCKED, */
-  { 0, 0x6666, 0, 0 },          /* DCC_PHASE_CONNECT, */
-  { 0, 0x8888, 0, 0 },          /* DCC_PHASE_CPP, */
-  { 0, 0xaaaa, 0, 0 },          /* DCC_PHASE_SEND, */
-  { 0, 0xcccc, 0, 0 },          /* DCC_PHASE_COMPILE, */
-  { 0, 0xeeee, 0, 0 },          /* DCC_PHASE_RECEIVE, */
-  { 0, 0xffff, 0xffff, 0 },     /* DCC_PHASE_DONE */
-};
-#endif
-
 /*
- * Colors used for drawing different state stripes.  First GdkColor
- * field is the assigned color index and zero here.
+ * Colors used for drawing different state stripes.
  *
  * These color names are from the GNOME standard palette.
  */
-const GdkColor task_color[] = {
-  { 0, 0x9999, 0, 0 },          /* DCC_PHASE_STARTUP, accent red dark */
-  { 0, 0x9999, 0, 0 },          /* DCC_PHASE_BLOCKED, accent red dark */
-  { 0, 0xc1c1, 0x6666, 0x5a5a }, /* DCC_PHASE_CONNECT, red medium  */
-  { 0, 0x8888, 0x7f7f, 0xa3a3 }, /* DCC_PHASE_CPP, purple medium*/
-  { 0, 0xe0e0, 0xc3c3, 0x9e9e }, /* DCC_PHASE_SEND, face skin medium*/
-  { 0, 0x8383, 0xa6a6, 0x7f7f }, /* DCC_PHASE_COMPILE, green medium */
-  { 0, 0x7575, 0x9090, 0xaeae }, /* DCC_PHASE_RECEIVE, blue medium*/
-  { 0, 0, 0, 0 },               /* DCC_PHASE_DONE */
+GdkRGBA task_color[DCC_PHASE_DONE];
+
+const char * task_color_string[] = {
+  "#999900000000", /* DCC_PHASE_STARTUP, accent red dark */
+  "#999900000000", /* DCC_PHASE_BLOCKED, accent red dark */
+  "#c1c166665a5a", /* DCC_PHASE_CONNECT, red medium  */
+  "#88887f7fa3a3", /* DCC_PHASE_CPP, purple medium*/
+  "#e0e0c3c39e9e", /* DCC_PHASE_SEND, face skin medium*/
+  "#8383a6a67f7f", /* DCC_PHASE_COMPILE, green medium */
+  "#75759090aeae", /* DCC_PHASE_RECEIVE, blue medium*/
+  "#000000000000", /* DCC_PHASE_DONE */
 };
+
+
+/**
+ * Initialize rgba colors for drawing in the right color for each state.
+ **/
+static void
+dcc_create_state_colors (void)
+{
+  enum dcc_phase i_state;
+  for (i_state = 0; i_state <= DCC_PHASE_DONE; i_state++)
+    {
+      printf("fisk state: %d, color: %s\n", i_state, task_color_string[i_state]);
+      gdk_rgba_parse(&task_color[i_state],task_color_string[i_state]);
+    }
+}
 
 
 static void
@@ -640,6 +642,7 @@ int main(int argc, char **argv)
 #endif
 
   /* do our own initialization */
+  dcc_create_state_colors();
   dcc_gnome_make_app ();
 
   /* Keep running until quit */

--- a/src/mon-gnome.c
+++ b/src/mon-gnome.c
@@ -587,8 +587,9 @@ static int dcc_gnome_make_app (void)
   /* Create the main window */
   mainwin = dcc_gnome_make_mainwin ();
 
-  /* Create a vbox for the contents */
-  topbox = gtk_vbox_new (FALSE, 0);
+  /* Create a gtkbox for the contents */
+  topbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+
   gtk_container_add (GTK_CONTAINER (mainwin),
                      topbox);
 
@@ -599,6 +600,13 @@ static int dcc_gnome_make_app (void)
                             &proc_align);
   gtk_container_add (GTK_CONTAINER (topbox),
                      proc_align);
+
+  gtk_box_set_child_packing (GTK_BOX (topbox),
+                             GTK_WIDGET (proc_align),
+                             TRUE,
+                             TRUE,
+                             0,
+                             GTK_PACK_START);
 
   gtk_box_pack_end (GTK_BOX (topbox),
                     load_bar,

--- a/src/mon-gnome.c
+++ b/src/mon-gnome.c
@@ -448,35 +448,6 @@ static gint dcc_gnome_load_update_cb (gpointer data)
 
 
 /**
- * Initialize graphics context for drawing into a widget in the right
- * color for each state.
- **/
-static void
-dcc_create_state_gcs (GtkWidget *widget)
-{
-  enum dcc_phase i_state;
-#if 0
-  for (i_state = 0; i_state < DCC_PHASE_DONE; i_state++)
-    {
-      dcc_phase_gc[i_state] = gdk_gc_new (widget->window);
-      gdk_gc_set_rgb_fg_color (dcc_phase_gc[i_state],
-                               (GdkColor *) &task_color[i_state]);
-
-    }
-#else
-  for (i_state = 0; i_state < DCC_PHASE_DONE; i_state++)
-    {
-      GdkWindow * gdk_window = gtk_widget_get_window (widget);
-      dcc_phase_gc[i_state] = gdk_cairo_create(gdk_window);
-      gdk_cairo_set_source_color (dcc_phase_gc[i_state],
-                               (GdkColor *) &task_color[i_state]);
-
-    }
-#endif
-}
-
-
-/**
  * Configure GtkTreeView with the right columns bound to
  * renderers, and a data model.
  **/
@@ -496,10 +467,6 @@ static void dcc_gnome_make_proc_view (GtkTreeModel *proc_model,
   selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (chart_treeview));
 
   gtk_tree_selection_set_mode (selection, GTK_SELECTION_NONE);
-
-  /* we can't create the gcs until the widget is first realized */
-  g_signal_connect_after (chart_treeview, "realize",
-                          G_CALLBACK (dcc_create_state_gcs), NULL);
 
   text_renderer = gtk_cell_renderer_text_new ();
   chart_renderer = dcc_cell_renderer_chart_new ();

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -257,20 +257,20 @@ dcc_cell_renderer_chart_get_type (void)
     {
       static const GTypeInfo cell_chart_info =
       {
-    sizeof (DccCellRendererChartClass),
-    NULL,        /* base_init */
-    NULL,        /* base_finalize */
-    (GClassInitFunc) dcc_cell_renderer_chart_class_init,
-    NULL,        /* class_finalize */
-    NULL,        /* class_data */
-    sizeof (DccCellRendererChart),
-    0,              /* n_preallocs */
-    (GInstanceInitFunc) dcc_cell_renderer_chart_init,
-        NULL                    /* value_table */
+        sizeof (DccCellRendererChartClass),
+        NULL,        /* base_init */
+        NULL,        /* base_finalize */
+        (GClassInitFunc) dcc_cell_renderer_chart_class_init,
+        NULL,        /* class_finalize */
+        NULL,        /* class_data */
+        sizeof (DccCellRendererChart),
+        0,           /* n_preallocs */
+        (GInstanceInitFunc) dcc_cell_renderer_chart_init,
+        NULL         /* value_table */
       };
 
       cell_chart_type =
-    g_type_register_static (GTK_TYPE_CELL_RENDERER,
+        g_type_register_static (GTK_TYPE_CELL_RENDERER,
                                 "DccCellRendererChart",
                                 &cell_chart_info, 0);
     }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -210,23 +210,6 @@ dcc_cell_renderer_chart_render (GtkCellRenderer      *cell,
 
 
 
-/**
- * Measure the size that we want to have allocated for this cell.
- */
-static void
-dcc_cell_renderer_chart_get_size (GtkCellRenderer *UNUSED (cell),
-                                  GtkWidget       *UNUSED (widget),
-                                  const GdkRectangle    *UNUSED (cell_area),
-                                  gint            *UNUSED (x_offset),
-                                  gint            *UNUSED (y_offset),
-                                  gint            *UNUSED (width),
-                                  gint            *UNUSED (height))
-{
-  /* default is fine */
-}
-
-
-
 
 static void
 dcc_cell_renderer_chart_class_init (DccCellRendererChartClass *class)
@@ -240,7 +223,6 @@ dcc_cell_renderer_chart_class_init (DccCellRendererChartClass *class)
   object_class->set_property = dcc_cell_renderer_chart_set_property;
 
   cell_class->render = dcc_cell_renderer_chart_render;
-  cell_class->get_size = dcc_cell_renderer_chart_get_size;
 
   spec = g_param_spec_pointer ("history",
                                "Slot history",

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -183,8 +183,6 @@ dcc_cell_renderer_chart_render (GtkCellRenderer      *cell,
   y1 = cell_area->y + ypad;
   bar_height = cell_area->height - (2 * ypad);
 
-
-
   /* bar width is chosen such that the history roughly fills the cell
      (but it must be at least 1).  We use the full history, not just
      the amount we currently have.  Round up. */
@@ -201,16 +199,9 @@ dcc_cell_renderer_chart_render (GtkCellRenderer      *cell,
 
       if (state != DCC_PHASE_DONE)
         {
-#if 0
-          gdk_draw_rectangle (window,
-                              dcc_phase_gc[state],
-                              TRUE, /* fill */
-                              x1, y1, bar_width, bar_height);
-#else
           gdk_cairo_set_source_color (cr, (GdkColor *) &task_color[state]);
           cairo_rectangle (cr, x1, y1, bar_width, bar_height);
           cairo_fill (cr);
-#endif
         }
 
       x1 += bar_width;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -183,17 +183,6 @@ dcc_cell_renderer_chart_render (GtkCellRenderer      *cell,
   y1 = cell_area->y + ypad;
   bar_height = cell_area->height - (2 * ypad);
 
-  const GdkColor task_color[] = {
-  { 0, 0x9999, 0, 0 },          /* DCC_PHASE_STARTUP, accent red dark */
-  { 0, 0x9999, 0, 0 },          /* DCC_PHASE_BLOCKED, accent red dark */
-  { 0, 0xc1c1, 0x6666, 0x5a5a }, /* DCC_PHASE_CONNECT, red medium  */
-  { 0, 0x8888, 0x7f7f, 0xa3a3 }, /* DCC_PHASE_CPP, purple medium*/
-  { 0, 0xe0e0, 0xc3c3, 0x9e9e }, /* DCC_PHASE_SEND, face skin medium*/
-  { 0, 0x8383, 0xa6a6, 0x7f7f }, /* DCC_PHASE_COMPILE, green medium */
-  { 0, 0x7575, 0x9090, 0xaeae }, /* DCC_PHASE_RECEIVE, blue medium*/
-  { 0, 0, 0, 0 },               /* DCC_PHASE_DONE */
-};
-
 
 
   /* bar width is chosen such that the history roughly fills the cell
@@ -218,10 +207,9 @@ dcc_cell_renderer_chart_render (GtkCellRenderer      *cell,
                               TRUE, /* fill */
                               x1, y1, bar_width, bar_height);
 #else
-gdk_cairo_set_source_color (cr, (GdkColor *) &task_color[state]);
-cairo_rectangle (cr, x1, y1, bar_width, bar_height);
-cairo_fill (cr);
-//cairo_destroy (cr);
+          gdk_cairo_set_source_color (cr, (GdkColor *) &task_color[state]);
+          cairo_rectangle (cr, x1, y1, bar_width, bar_height);
+          cairo_fill (cr);
 #endif
         }
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -212,7 +212,8 @@ dcc_cell_renderer_chart_render (GtkCellRenderer      *cell,
 
 
 static void
-dcc_cell_renderer_chart_class_init (DccCellRendererChartClass *class)
+dcc_cell_renderer_chart_class_init (DccCellRendererChartClass *class,
+                                    gpointer UNUSED(klass))
 {
   GParamSpec *spec;
 
@@ -237,7 +238,8 @@ dcc_cell_renderer_chart_class_init (DccCellRendererChartClass *class)
 
 /* Instance initialization */
 static void
-dcc_cell_renderer_chart_init (DccCellRendererChart *cell)
+dcc_cell_renderer_chart_init (DccCellRendererChart *cell,
+                              gpointer UNUSED(klass))
 {
   cell->history = NULL;
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -199,7 +199,7 @@ dcc_cell_renderer_chart_render (GtkCellRenderer      *cell,
 
       if (state != DCC_PHASE_DONE)
         {
-          gdk_cairo_set_source_color (cr, (GdkColor *) &task_color[state]);
+          gdk_cairo_set_source_rgba (cr, &task_color[state]);
           cairo_rectangle (cr, x1, y1, bar_width, bar_height);
           cairo_fill (cr);
         }

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -42,10 +42,5 @@ typedef struct _DccCellRendererChartClass DccCellRendererChartClass;
 GType            dcc_cell_renderer_chart_get_type (void);
 GtkCellRenderer *dcc_cell_renderer_chart_new      (void);
 
-
-//extern GdkGC *dcc_phase_gc[DCC_PHASE_DONE];
-extern cairo_t *dcc_phase_gc[DCC_PHASE_DONE];
-
 extern const guint dcc_max_history_queue;
-
 extern const GdkColor task_color[];

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -43,4 +43,4 @@ GType            dcc_cell_renderer_chart_get_type (void);
 GtkCellRenderer *dcc_cell_renderer_chart_new      (void);
 
 extern const guint dcc_max_history_queue;
-extern const GdkColor task_color[];
+extern GdkRGBA task_color[];

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -43,6 +43,7 @@ GType            dcc_cell_renderer_chart_get_type (void);
 GtkCellRenderer *dcc_cell_renderer_chart_new      (void);
 
 
-extern GdkGC *dcc_phase_gc[DCC_PHASE_DONE];
+//extern GdkGC *dcc_phase_gc[DCC_PHASE_DONE];
+extern cairo_t *dcc_phase_gc[DCC_PHASE_DONE];
 
 extern const guint dcc_max_history_queue;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -47,3 +47,5 @@ GtkCellRenderer *dcc_cell_renderer_chart_new      (void);
 extern cairo_t *dcc_phase_gc[DCC_PHASE_DONE];
 
 extern const guint dcc_max_history_queue;
+
+extern const GdkColor task_color[];


### PR DESCRIPTION

GTK 2 has reached it's end of life: https://blog.gtk.org/2020/12/16/gtk-4-0/

So I thought this would be a good exercise for me to port this as I use distccmon-gnome from time to time and would like not to loose it. 

This should be ready to go and compiles without warnings for me.

Attached is a screenshot of both:
![Selection_195](https://user-images.githubusercontent.com/352202/103483262-47f53080-4de6-11eb-9004-f6fc583f6441.png)
