### PR TITLE
Skip distributing LTO cc invocations

### DIFF
--- a/src/arg.c
+++ b/src/arg.c
@@ -189,6 +189,9 @@ int dcc_scan_args(char *argv[], char **input_file, char **output_file,
                 rs_trace("-mtune=native optimizes for local machine; "
                          "must be local");
                 return EXIT_DISTCC_FAILED;
+            } else if (!strcmp(a, "-flto")) {
+                rs_trace("LTO cc invocations are not worth distributing");
+                return EXIT_DISTCC_FAILED;
             } else if (str_startswith("-Wa,", a)) {
                 /* Look for assembler options that would produce output
                  * files and must be local.


### PR DESCRIPTION
When distcc is configured as the system compiler, sometimes it ends up being used on LTO builds. In this case it's faster to run the `cc` invocations locally, since most of the work of the compiler is done in the linker.

I'm guessing they'll be some discussion on this feature but I thought I'd rather post a patch.