### PR TITLE
Improved cross-compilation with clang

### DIFF
--- a/src/argutil.c
+++ b/src/argutil.c
@@ -67,6 +67,19 @@ int dcc_argv_search(char **a,
 }
 
 
+/**
+ * Return true if argv contains argument starting with needle.
+ */
+int dcc_argv_startswith(char **a,
+                        const char *needle)
+{
+    size_t needle_len = strlen(needle);
+    for (; *a; a++)
+        if (!strncmp(*a, needle, needle_len))
+            return 1;
+    return 0;
+}
+
 unsigned int dcc_argv_len(char **a)
 {
     unsigned int i;

--- a/src/compile.c
+++ b/src/compile.c
@@ -557,7 +557,12 @@ static void dcc_add_clang_target(char **argv)
     else
         return;
 
+    /* -target aarch64-linux-gnu */
     if (dcc_argv_search(argv, "-target"))
+        return;
+
+    /* --target=aarch64-linux-gnu */
+    if (dcc_argv_startswith(argv, "--target"))
         return;
 
     rs_log_info("Adding '-target %s' to support clang cross-compilation.",

--- a/src/distcc.h
+++ b/src/distcc.h
@@ -262,6 +262,7 @@ int dcc_expand_preprocessor_options(char ***argv_ptr);
 /* argutil.c */
 unsigned int dcc_argv_len(char **a);
 int dcc_argv_search(char **a, const char *);
+int dcc_argv_startswith(char **a, const char *);
 int dcc_copy_argv(char **argv, char ***out_argv, int extra_args);
 int dcc_argv_append(char **argv, char *toadd);
 char *dcc_argv_tostr(char **a);


### PR DESCRIPTION
With this patch I can cross-compile Linux kernel with clang and distcc.
Otherwise both remote compilation and local fallback fail like this:

```
cat > foo.c <<-EOF
int main(int argc, char **argv) { return 0; }
EOF
env DISTCC_HOSTS=127.0.0.1 distcc clang -c --target=aarch64-linux-gnu- foo.c

error: unknown target triple 'unknown', please use -triple or -arch
distcc[304773] ERROR: compile foo.c on 127.0.0.1 failed
distcc[304773] (dcc_build_somewhere) Warning: remote compilation of 'foo.c' failed, retrying locally
distcc[304773] Warning: failed to distribute foo.c to 127.0.0.1, running locally instead
error: unknown target triple 'unknown', please use -triple or -arch
distcc[304773] ERROR: compile foo.c on localhost failed
```

Linux' kernel makefiles specify the target arch with `--target=foo`,
and distcc expects `-target foo`, hence the problem.

Closes: #416