### PR TITLE
dcc_gcc_rewrite_fqn: avoid heap corruption

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -584,7 +584,7 @@ static int dcc_gcc_rewrite_fqn(char **argv)
         return -ENOENT;
 
 
-    newcmd_len = strlen(target_with_vendor) + 1 + strlen(argv[0] + 1);
+    newcmd_len = strlen(target_with_vendor) + 1 + strlen(argv[0]) + 1;
     newcmd = malloc(newcmd_len);
     if (!newcmd)
         return -ENOMEM;


### PR DESCRIPTION
On ALT Linux I've run into the following bug:

distcc gcc -Wall -std=gnu89 -I. -O2 -o hello.o -c hello.c
free(): invalid next size (fast)
Aborted (core dumped)

Apparently dcc_gcc_rewrite writes beyond the allocated memory:

valgrind --leak-check=full -v ./distcc gcc -Wall -std=gnu89 -I. -O2 -o hello.o -c hello.c

==11382== ERROR SUMMARY: 53 errors from 5 contexts (suppressed: 0 from 0)
==11382==
==11382== 1 errors in context 1 of 5:
==11382== Invalid write of size 1
==11382==    at 0x4C349D8: strcat (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11382==    by 0x10D165: dcc_gcc_rewrite_fqn (compile.c:611)
==11382==    by 0x10D4B4: dcc_build_somewhere (compile.c:725)
==11382==    by 0x10DC01: dcc_build_somewhere_timed (compile.c:1014)
==11382==    by 0x10E380: main (distcc.c:352)
==11382==  Address 0x544e828 is 1 bytes after a block of size 23 alloc'd
==11382==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11382==    by 0x10D087: dcc_gcc_rewrite_fqn (compile.c:588)
==11382==    by 0x10D4B4: dcc_build_somewhere (compile.c:725)
==11382==    by 0x10DC01: dcc_build_somewhere_timed (compile.c:1014)
==11382==    by 0x10E380: main (distcc.c:352)
==11382==
==11382==
==11382== 1 errors in context 2 of 5:
==11382== Invalid write of size 1
==11382==    at 0x4C349C8: strcat (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11382==    by 0x10D165: dcc_gcc_rewrite_fqn (compile.c:611)
==11382==    by 0x10D4B4: dcc_build_somewhere (compile.c:725)
==11382==    by 0x10DC01: dcc_build_somewhere_timed (compile.c:1014)
==11382==    by 0x10E380: main (distcc.c:352)
==11382==  Address 0x544e827 is 0 bytes after a block of size 23 alloc'd
==11382==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11382==    by 0x10D087: dcc_gcc_rewrite_fqn (compile.c:588)
==11382==    by 0x10D4B4: dcc_build_somewhere (compile.c:725)
==11382==    by 0x10DC01: dcc_build_somewhere_timed (compile.c:1014)
==11382==    by 0x10E380: main (distcc.c:352)

and ALT Linux' hardened glibc does not quite like that.
Correctly compute the `newcmd_len` to avoid the problem.

ALTBUG: #40425