### PR TITLE
Revert "Skip distributing LTO cc invocations"

### DIFF
--- a/src/arg.c
+++ b/src/arg.c
@@ -189,9 +189,6 @@ int dcc_scan_args(char *argv[], char **input_file, char **output_file,
                 rs_trace("-mtune=native optimizes for local machine; "
                          "must be local");
                 return EXIT_DISTCC_FAILED;
-            } else if (!strcmp(a, "-flto")) {
-                rs_trace("LTO cc invocations are not worth distributing");
-                return EXIT_DISTCC_FAILED;
             } else if (str_startswith("-Wa,", a)) {
                 /* Look for assembler options that would produce output
                  * files and must be local.


### PR DESCRIPTION
This reverts commit 8dacd28d888210753e9457eb31175d8e2a1c348e.
The "LTO invocations are not worth distributing" statement is in general wrong.
GCC generates the (target) machine code for every compilation unit even with `-flto` (so it makes sense to distribute these). And the whole program analysis is not guaranteed to be the bottleneck of the build.
As a matter of fact distributing LTO compilations reduces the build time of LLVM/clang, GCC, and other programs (especially C++ ones).

Closes: #428