### PR TITLE
distccd: keep looking for approved compilers in /usr/lib/distcc ...

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -515,7 +515,9 @@ lsdistcc@EXEEXT@: $(lsdistcc_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(lsdistcc_obj) $(LIBS)
 
 update-distcc-symlinks: $(update_distcc_symlinks_PY)
-	cp $< $@
+	sed -e "s;\@prefix\@;${prefix};g" $< > $@.tmp
+	chmod +x $@.tmp
+	mv $@.tmp $@
 
 h_exten@EXEEXT@: $(h_exten_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_exten_obj) $(LIBS)

--- a/src/serve.c
+++ b/src/serve.c
@@ -395,13 +395,8 @@ static int dcc_check_compiler_whitelist(char *_compiler_name)
 
 #ifdef HAVE_FSTATAT
     int dirfd = open(LIBDIR "/distcc", O_RDONLY);
-    if (dirfd < 0) {
-        if (errno == ENOENT)
-            rs_log_crit("no %s", LIBDIR "/distcc");
-        return EXIT_DISTCC_FAILED;
-    }
 
-    if (faccessat(dirfd, compiler_name, X_OK, 0) < 0) {
+    if (dirfd < 0 || faccessat(dirfd, compiler_name, X_OK, 0) < 0) {
         char *compiler_path = NULL;
         if (asprintf(&compiler_path, "/usr/lib/distcc/%s", compiler_name) >= 0) {
             if (access(compiler_path, X_OK) < 0) {

--- a/update-distcc-symlinks.py
+++ b/update-distcc-symlinks.py
@@ -2,7 +2,7 @@
 
 import subprocess, string, os, stat, re
 
-distcc_dir = "/usr/lib/distcc"
+distcc_dir = "@prefix@/lib/distcc"
 gcc_dir = "/usr/lib/gcc"
 gcccross_dir = "/usr/lib/gcc-cross"
 old_symlinks = set()


### PR DESCRIPTION
... instead of bailing out if `$prefix/lib/distcc` directory does not exist

Closes: #431 