### PR TITLE
masquerade mode improvements for rpm-based systems

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -59,7 +59,7 @@ include_server_builddir = $(builddir)/_include_server
 
 # These must be done from here, not from autoconf, because they can 
 # contain variable expansions written in Make syntax.  Ew.
-DIR_DEFS = -DLIBDIR="\"${libdir}\"" -DSYSCONFDIR="\"${sysconfdir}\"" -DICONDIR="\"${icondir}\""
+DIR_DEFS = -DLIBDIR="\"${prefix}/lib\"" -DSYSCONFDIR="\"${sysconfdir}\"" -DICONDIR="\"${icondir}\""
 
 # arguments to pkgconfig
 GNOME_PACKAGES = @GNOME_PACKAGES@

--- a/update-distcc-symlinks.py
+++ b/update-distcc-symlinks.py
@@ -7,8 +7,11 @@ import stat
 import re
 
 distcc_dir = "@prefix@/lib/distcc"
-gcc_dir = "/usr/lib/gcc"
-gcccross_dir = "/usr/lib/gcc-cross"
+GCC_LIBEXEC_DIRS = (
+    '/usr/lib/gcc',  # Debian native GCC compilers
+    '/usr/lib/gcc-cross',  # Debian GCC cross-compilers
+    '/usr/libexec/gcc', # rpm-based distros
+)
 old_symlinks = set()
 new_symlinks = set()
 standard_names = ["cc", "c++", "c89", "c99"]
@@ -18,53 +21,56 @@ if not os.access(distcc_dir, os.X_OK):
 
 
 def consider(name):
-    if os.access("/usr/bin/%(name)s" % vars(), os.X_OK):
+    if os.access(f"/usr/bin/{name}", os.X_OK):
         new_symlinks.add(name)
         print(name)
 
 
-def consider_gcc(prefix, suffix):
-    consider("%(prefix)sgcc%(suffix)s" % vars())
-    consider("%(prefix)sg++%(suffix)s" % vars())
+def consider_gcc(prefix, suffix=""):
+    consider(f"{prefix}gcc{suffix}")
+    consider(f"{prefix}g++{suffix}")
 
 
 def consider_clang(suffix):
-    consider("clang%(suffix)s" % vars())
-    consider("clang++%(suffix)s" % vars())
+    consider(f"clang{suffix}")
+    consider(f"clang++{suffix}")
 
 
 for x in standard_names:
     consider(x)
 
-consider_gcc("", "")
-consider_gcc("c89-", "")
-consider_gcc("c99-", "")
-try:
-    for gnu_host in os.listdir(gcc_dir):
-        consider_gcc("%(gnu_host)s-" % vars(), "")
-        for version in os.listdir(gcc_dir + "/" + gnu_host):
-            consider_gcc("", "-%(version)s" % vars())
-            consider_gcc("%(gnu_host)s-" % vars(), "-%(version)s" % vars())
-except FileNotFoundError:
-    pass
-except NotADirectoryError:
-    pass
-try:
-    for gnu_host in os.listdir(gcccross_dir):
-        consider_gcc("%(gnu_host)s-" % vars(), "")
-        for version in os.listdir(gcccross_dir + "/" + gnu_host):
-            consider_gcc("", "-%(version)s" % vars())
-            consider_gcc("%(gnu_host)s-" % vars(), "-%(version)s" % vars())
-except FileNotFoundError:
-    pass
-except NotADirectoryError:
-    pass
+consider_gcc("")
+consider_gcc("c89-")
+consider_gcc("c99-")
+
+
+def sloppy_listdir(thedir):
+    try:
+        return os.listdir(thedir)
+    except FileNotFoundError:
+        pass
+    except NotADirectoryError:
+        pass
+    return []
+
+
+def scan_gcc_libexec(gcc_dir):
+    for gnu_host in sloppy_listdir(gcc_dir):
+        consider_gcc(f"{gnu_host}-")
+        for version in sloppy_listdir(gcc_dir + "/" + gnu_host):
+            consider_gcc("", f"-{version}")
+            consider_gcc(f"{gnu_host}-", f"-{version}")
+
+
+for gcc_dir in GCC_LIBEXEC_DIRS:
+    scan_gcc_libexec(gcc_dir)
+
 
 consider_clang("")
 for ent in os.listdir("/usr/lib"):
     if ent.startswith("llvm-"):
         version = ent.split("-")[1]
-        consider_clang("-%(version)s" % vars())
+        consider_clang(f"-{version}")
 
 for name in os.listdir(distcc_dir):
     mode = os.lstat(distcc_dir + "/" + name).st_mode
@@ -80,7 +86,4 @@ for link in old_symlinks:
 
 for link in new_symlinks:
     if link not in old_symlinks:
-        if os.access("/usr/bin/distcc", os.X_OK):
-            os.symlink("../../bin/distcc", distcc_dir + "/" + link)
-        else:
-            os.symlink("../../local/bin/distcc", distcc_dir + "/" + link)
+        os.symlink("../../bin/distcc", distcc_dir + "/" + link)

--- a/update-distcc-symlinks.py
+++ b/update-distcc-symlinks.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
-import subprocess, string, os, stat, re
+import subprocess
+import string
+import os
+import stat
+import re
 
 distcc_dir = "@prefix@/lib/distcc"
 gcc_dir = "/usr/lib/gcc"
@@ -10,69 +14,73 @@ new_symlinks = set()
 standard_names = ["cc", "c++", "c89", "c99"]
 
 if not os.access(distcc_dir, os.X_OK):
-  os.mkdir(distcc_dir)
+    os.mkdir(distcc_dir)
+
 
 def consider(name):
-  if os.access("/usr/bin/%(name)s" % vars(), os.X_OK):
-    new_symlinks.add(name)
-    print(name)
+    if os.access("/usr/bin/%(name)s" % vars(), os.X_OK):
+        new_symlinks.add(name)
+        print(name)
+
 
 def consider_gcc(prefix, suffix):
-  consider("%(prefix)sgcc%(suffix)s" % vars())
-  consider("%(prefix)sg++%(suffix)s" % vars())
+    consider("%(prefix)sgcc%(suffix)s" % vars())
+    consider("%(prefix)sg++%(suffix)s" % vars())
+
 
 def consider_clang(suffix):
-  consider("clang%(suffix)s" % vars())
-  consider("clang++%(suffix)s" % vars())
+    consider("clang%(suffix)s" % vars())
+    consider("clang++%(suffix)s" % vars())
+
 
 for x in standard_names:
-  consider(x)
+    consider(x)
 
 consider_gcc("", "")
 consider_gcc("c89-", "")
 consider_gcc("c99-", "")
 try:
-  for gnu_host in os.listdir(gcc_dir):
-    consider_gcc("%(gnu_host)s-" % vars(), "")
-    for version in os.listdir(gcc_dir + "/" + gnu_host):
-      consider_gcc("", "-%(version)s" % vars())
-      consider_gcc("%(gnu_host)s-" % vars(), "-%(version)s" % vars())
+    for gnu_host in os.listdir(gcc_dir):
+        consider_gcc("%(gnu_host)s-" % vars(), "")
+        for version in os.listdir(gcc_dir + "/" + gnu_host):
+            consider_gcc("", "-%(version)s" % vars())
+            consider_gcc("%(gnu_host)s-" % vars(), "-%(version)s" % vars())
 except FileNotFoundError:
-  pass
+    pass
 except NotADirectoryError:
-  pass
+    pass
 try:
-  for gnu_host in os.listdir(gcccross_dir):
-    consider_gcc("%(gnu_host)s-" % vars(), "")
-    for version in os.listdir(gcccross_dir + "/" + gnu_host):
-      consider_gcc("", "-%(version)s" % vars())
-      consider_gcc("%(gnu_host)s-" % vars(), "-%(version)s" % vars())
+    for gnu_host in os.listdir(gcccross_dir):
+        consider_gcc("%(gnu_host)s-" % vars(), "")
+        for version in os.listdir(gcccross_dir + "/" + gnu_host):
+            consider_gcc("", "-%(version)s" % vars())
+            consider_gcc("%(gnu_host)s-" % vars(), "-%(version)s" % vars())
 except FileNotFoundError:
-  pass
+    pass
 except NotADirectoryError:
-  pass
+    pass
 
 consider_clang("")
 for ent in os.listdir("/usr/lib"):
-  if ent.startswith("llvm-"):
-    version = ent.split("-")[1]
-    consider_clang("-%(version)s" % vars())
+    if ent.startswith("llvm-"):
+        version = ent.split("-")[1]
+        consider_clang("-%(version)s" % vars())
 
 for name in os.listdir(distcc_dir):
-  mode = os.lstat(distcc_dir + "/" + name).st_mode
-  if stat.S_ISLNK(mode):
-    if os.access(distcc_dir + "/" + name, os.X_OK):
-      old_symlinks.add(name)
-    else:
-      os.unlink(distcc_dir + "/" + name)
+    mode = os.lstat(distcc_dir + "/" + name).st_mode
+    if stat.S_ISLNK(mode):
+        if os.access(distcc_dir + "/" + name, os.X_OK):
+            old_symlinks.add(name)
+        else:
+            os.unlink(distcc_dir + "/" + name)
 
 for link in old_symlinks:
-  if link not in new_symlinks:
-    os.unlink(distcc_dir + "/" + link)
+    if link not in new_symlinks:
+        os.unlink(distcc_dir + "/" + link)
 
 for link in new_symlinks:
-  if link not in old_symlinks:
-    if os.access("/usr/bin/distcc", os.X_OK):
-      os.symlink("../../bin/distcc", distcc_dir + "/" + link)
-    else:
-      os.symlink("../../local/bin/distcc", distcc_dir + "/" + link)
+    if link not in old_symlinks:
+        if os.access("/usr/bin/distcc", os.X_OK):
+            os.symlink("../../bin/distcc", distcc_dir + "/" + link)
+        else:
+            os.symlink("../../local/bin/distcc", distcc_dir + "/" + link)


### PR DESCRIPTION
  On ARM64 rpm-based distros GCC bits are installed into `/usr/lib64/gcc` and `/usr/libexec/gcc` directories. However `update-distcc-symlinks` does not scan these directories. As a result `update-distcc-symlinks` does NOT create symlinks to
 
* versioned GCC binaries (`gcc-8`, `gcc-10`, etc)
* fully qualified GCC binaries (`aarch64-linux-gnu-gcc-8`, etc)

With this patchset `update-distcc-symlinks` correctly work on such systems.


Also distcc/distccd always use `/usr/lib/distcc` (both on 32-bit and 64-bit hosts) so the masquerade mode always works as advertised in the manual:
```
PATH=/usr/lib/distcc:$PATH make -j32
```

Closes: #435
