### PR TITLE
Restrict number of retries when backoff is disabled

### DIFF
--- a/src/backoff.c
+++ b/src/backoff.c
@@ -52,6 +52,19 @@
 
 static int dcc_backoff_period = 60; /* seconds */
 
+static int dcc_get_backoff_period(void)
+{
+    char *bp;
+    bp = getenv("DISTCC_BACKOFF_PERIOD");
+    if (bp)
+        dcc_backoff_period = atoi(bp);
+    return dcc_backoff_period;
+}
+
+int dcc_backoff_is_enabled(void)
+{
+    return dcc_get_backoff_period() != 0;
+}
 
 /**
  * Remember that this host is working OK.
@@ -61,23 +74,17 @@ static int dcc_backoff_period = 60; /* seconds */
  **/
 int dcc_enjoyed_host(const struct dcc_hostdef *host)
 {
-    char *bp;
-
     /* special-case: if DISTCC_BACKOFF_PERIOD==0, don't manage backoff files */
-    bp = getenv("DISTCC_BACKOFF_PERIOD");
-    if (bp && (atoi(bp) == 0))
-	return 0;
+    if (!dcc_backoff_is_enabled())
+        return 0;
 
     return dcc_remove_timefile("backoff", host);
 }
 
 int dcc_disliked_host(const struct dcc_hostdef *host)
 {
-    char *bp;
-
     /* special-case: if DISTCC_BACKOFF_PERIOD==0, don't manage backoff files */
-    bp = getenv("DISTCC_BACKOFF_PERIOD");
-    if (bp && (atoi(bp) == 0))
+    if (!dcc_backoff_is_enabled())
 	return 0;
 
     /* i hate you (but only for dcc_backoff_period seconds) */
@@ -108,14 +115,8 @@ static int dcc_check_backoff(struct dcc_hostdef *host)
 int dcc_remove_disliked(struct dcc_hostdef **hostlist)
 {
     struct dcc_hostdef *h;
-    char *bp;
 
-    bp = getenv("DISTCC_BACKOFF_PERIOD");
-    if (bp)
-	dcc_backoff_period = atoi(bp);
-
-    /* special-case: if DISTCC_BACKOFF_PERIOD==0, don't manage backoff files */
-    if (dcc_backoff_period == 0)
+    if (!dcc_backoff_is_enabled())
 	return 0;
 
     while ((h = *hostlist) != NULL) {

--- a/src/distcc.h
+++ b/src/distcc.h
@@ -190,6 +190,7 @@ int dcc_support_masquerade(char *argv[], char *progname, int *);
 int dcc_enjoyed_host(const struct dcc_hostdef *host);
 int dcc_disliked_host(const struct dcc_hostdef *host);
 int dcc_remove_disliked(struct dcc_hostdef **hostlist);
+int dcc_backoff_is_enabled(void);
 
 
 


### PR DESCRIPTION
Since the commit a7dd5cf90e8c ("Try a new host after failing to connect instead of immediately falling back to localhost") distcc tries to choose a different host on connection/protocol errors. However when backoff is disabled (DISTCC_BACKOFF_PERIOD=0) distcc keeps retrying forever.
    
To avoid the problem limit the number of retries (currently to 3) when backoff is disabled.

Closes: #434