### PR TITLE
Check for DISTCC_CMDLIST in addition to masquerade directory

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -155,10 +155,15 @@ static int dcc_setup_daemon_path(void)
 
 static void dcc_warn_masquerade_whitelist(void) {
     DIR *d, *e;
-    const char *warn = "You must see up masquerade" \
-                       " (see distcc(1)) to list whitelisted compilers or pass" \
+    const char *warn = "You must set up masquerade" \
+                       " (see distcc(1)) to list whitelisted compilers, set DISTCC_CMDLIST or pass" \
                        " --enable-tcp-insecure. To set up masquerade automatically" \
                        " run update-distcc-symlinks.";
+
+    if (getenv("DISTCC_CMDLIST"))
+    {
+        return;
+    }
 
     e = opendir("/usr/lib/distcc");
     d = opendir(LIBDIR "/distcc");


### PR DESCRIPTION
Distcc supports the masquerade directory that contains links to the actual compilers. However, the implementation uses a hard-coded location for the masquerade directory (/usr/lib/distcc, and LIBDIR/distcc). These directories might not exist on some platforms and users might not have permissions to create them.

The other option is to set `--enable-tcp-insecure` which would open distcc up to arbitrary commands which is a security risk.

There's actually a third option for distccd in form of the `DISTCC_CMDLIST` environment variable. This change checks whether this environment variable is set in the daemon.