### PR TITLE
Fix various source documentation typos

### DIFF
--- a/doc/web/man/distccmon_text_1.html
+++ b/doc/web/man/distccmon_text_1.html
@@ -94,7 +94,7 @@ ID of the distcc client process.<BR>
 <DD>
 Identifies the phase of operation.  In order these may be &quot;Startup&quot;,
 &quot;Blocked&quot;, &quot;Connected&quot;, &quot;Preprocess&quot;,
-&quot;Conect&quot;, &quot;Send&quot;, &quot;Receive&quot; and
+&quot;Connect&quot;, &quot;Send&quot;, &quot;Receive&quot; and
 &quot;Done&quot;.<BR>
 </DD>
 <DT>

--- a/man/distccmon-text.1
+++ b/man/distccmon-text.1
@@ -27,7 +27,7 @@ ID of the distcc client process.
 .TP
 .I STATE
 Identifies the phase of operation.  In order these may be "Startup",
-"Blocked", "Connected", "Preprocess", "Conect", "Send", "Receive" and
+"Blocked", "Connected", "Preprocess", "Connect", "Send", "Receive" and
 "Done".
 .TP
 .I FILE

--- a/src/auth_distcc.c
+++ b/src/auth_distcc.c
@@ -262,7 +262,7 @@ static int dcc_gssapi_establish_secure_context(const struct dcc_hostdef *host,
 
 /*
  * Attempt handshake exchange with the server to indicate client's
- * desire to authentciate.
+ * desire to authenticate.
  *
  * @param to_net_sd.	Socket to write to.
  *

--- a/src/auth_distccd.c
+++ b/src/auth_distccd.c
@@ -238,7 +238,7 @@ static int dcc_gssapi_accept_secure_context(int to_net_sd,
 
 /*
  * Attempt handshake exchange with the client to indicate server's
- * desire to authentciate.
+ * desire to authenticate.
  *
  * @param from_net_sd.	Socket to read from.
  *


### PR DESCRIPTION
Found via `codespell -q 3 -S ./ChangeLog -L ake,ba,msdos,paralel,te`