### PR TITLE
Support `-f*-prefix-map` compiler options

### DIFF
--- a/src/serve.c
+++ b/src/serve.c
@@ -485,6 +485,49 @@ static int tweak_input_argument_for_server(char **argv,
 }
 
 
+static const char *prefix_map_options[] = {
+    "-ffile-prefix-map=",
+    "-fmacro-prefix-map=",
+    "-fdebug-prefix-map=",
+    "-fprofile-prefix-map=",
+    NULL
+};
+
+
+/**
+ * Prepend @p root_dir to arguments of -f*-prefix-map= options that are absolute.
+ **/
+static int tweak_prefix_map_arguments_for_server(char **argv,
+                                                 const char *root_dir)
+{
+    int index_of_first_filename_char = 0;
+    const char *prefix_map_option;
+    unsigned int i, j;
+    for (i = 0; argv[i]; ++i) {
+        for (j = 0; prefix_map_options[j]; ++j) {
+            if (str_startswith(prefix_map_options[j], argv[i])) {
+                prefix_map_option = prefix_map_options[j];
+                index_of_first_filename_char = strlen(prefix_map_option);
+                if (argv[i][index_of_first_filename_char] == '/') {
+                    char *buf;
+                    checked_asprintf(&buf, "%s%s%s",
+                                prefix_map_option,
+                                root_dir,
+                                argv[i] + index_of_first_filename_char);
+                    if (buf == NULL) {
+                        return EXIT_OUT_OF_MEMORY;
+                    }
+                    free(argv[i]);
+                    argv[i] = buf;
+                }
+                break;  /* from the inner loop; go look at the next argument */
+            }
+        }
+    }
+    return 0;
+}
+
+
 /**
  * Prepend @p root_dir to arguments of include options that are absolute.
  **/
@@ -597,6 +640,7 @@ static int tweak_arguments_for_server(char **argv,
     dcc_argv_append(*tweaked_argv, strdup(deps_fname));
 
     tweak_include_arguments_for_server(*tweaked_argv, root_dir);
+    tweak_prefix_map_arguments_for_server(*tweaked_argv, root_dir);
     tweak_input_argument_for_server(*tweaked_argv, root_dir);
     return 0;
 }

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1250,7 +1250,7 @@ class Gdb_Case(CompileHello_Case):
 
     def compiler(self):
         """Command for compiling and linking."""
-        return self._cc + " -g ";
+        return self._cc + " -g "
 
     def compileCmd(self):
         """Return command to compile source"""
@@ -1296,6 +1296,9 @@ class Gdb_Case(CompileHello_Case):
 
         CompileHello_Case.runtest (self)
 
+    def gdbCommands(self):
+        return 'break main\nrun\nnext\n'
+
     def checkBuiltProgram(self):
         # On windows, the binary may be called testtmp.exe.  Check both
         if os.path.exists('link/testtmp.exe'):
@@ -1309,7 +1312,7 @@ class Gdb_Case(CompileHello_Case):
         # the gdb commands directly on the commandline using gdb --ex,
         # is not as portable since only newer gdb's support it.)
         f = open('gdb_commands', 'w')
-        f.write('break main\nrun\nnext\n')
+        f.write(self.gdbCommands())
         f.close()
         out, errs = self.runcmd("gdb -nh --batch --command=gdb_commands "
                                 "link/%s </dev/null" % testtmp_exe)
@@ -1401,6 +1404,20 @@ class GdbOpt3_Case(Gdb_Case):
     def compiler(self):
         """Command for compiling and linking."""
         return self._cc + " -g -O3 ";
+
+class GdbPrefixMap_Case(Gdb_Case):
+    def compiler(self):
+        """Command for compiling and linking."""
+        # Before GCC 6, the -fdebug-prefix-map=... option was recorded in the
+        # DW_AT_producer section: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69821
+        # Here, use -gno-record-gcc-switches so that we do not see
+        # "replaced 1 occurrences of" from dcc_fix_debug_info in distccd.log.
+        # We could check this automatically, but it doesn't add much value.
+        return (self._cc + " -g -fdebug-prefix-map=%s=." % os.getcwd() +
+                " -gno-record-gcc-switches")
+
+    def gdbCommands(self):
+        return 'directory %s\n' % os.getcwd() + super().gdbCommands()
 
 class CompressedCompile_Case(CompileHello_Case):
     """Test compilation with compression.
@@ -2204,6 +2221,7 @@ tests = [
          GdbOpt1_Case,
          GdbOpt2_Case,
          GdbOpt3_Case,
+         GdbPrefixMap_Case,
          Lsdistcc_Case,
          BadLogFile_Case,
          ScanArgs_Case,


### PR DESCRIPTION
In pump mode, distcc rewrites the debug info on the server before
returning the result (see `dcc_fix_debug_info`). However, when
`-ffile-prefix-map` or similar compiler options are passed,
the compiler is unable to perform the substitution since the path on
the server is different. The rewriting of distcc still kicks in,
and the net result on the client side is that the `-prefix-map`
option is not respected.

This is fixed by simply treating the `-f*-prefix-map` options
analogously to the include arguments.