### PR TITLE
Compile files with .incbin assembler directive locally

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -700,7 +700,7 @@ dcc_build_somewhere(char *argv[],
     int cpu_lock_fd = -1, local_cpu_lock_fd = -1;
     int ret;
     int remote_ret = 0;
-    int retry_count = 0, max_retries;
+    int retry_count = 0, max_retries, remote_unsupported = 0;
     struct dcc_hostdef *host = NULL;
     char *discrepancy_filename = NULL;
     char **new_argv;
@@ -850,9 +850,15 @@ dcc_build_somewhere(char *argv[],
                                   needs_dotd ? deps_fname : NULL,
                                   server_stderr_fname,
                                   cpp_pid, local_cpu_lock_fd,
-                  host, status)) != 0) {
+                  host, status, &remote_unsupported)) != 0) {
         /* Returns zero if we successfully ran the compiler, even if
          * the compiler itself bombed out. */
+
+        if (remote_unsupported) {
+	    /* Local files are necessary for compilation of the *preprocessed*
+	     * source (i.e. due to .incbin assembler directive). */
+	    goto fallback_unsupported;
+	}
 
         /* dcc_compile_remote() already unlocked local_cpu_lock_fd. */
         local_cpu_lock_fd = -1;
@@ -953,6 +959,12 @@ dcc_build_somewhere(char *argv[],
                host->hostdef_string);
     } else {
         rs_log_warning("failed to distribute, running locally instead");
+    }
+
+    fallback_unsupported:
+    if (remote_unsupported) {
+        rs_log_warning("%s: can't distribute due to unsupported directives, running locally",
+                       input_fname ? input_fname : "(unknown)");
     }
 
   lock_local:

--- a/src/compile.h
+++ b/src/compile.h
@@ -33,7 +33,8 @@ int dcc_compile_remote(char **argv,
                        pid_t cpp_pid,
                        int local_cpu_lock_fd,
                        struct dcc_hostdef *host,
-                       int *status);
+                       int *status,
+                       int *unsupported);
 
 /* compile.c */
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -149,6 +149,50 @@ dcc_send_header(int net_fd,
     return 0;
 }
 
+/**
+ * Check if the preprocessed source depends on local file(s)
+ *
+ * @param cpp_fname preprocessed file to check
+ * @param input_fname corresponding source file name
+ *
+ * @return 0 if no local dependencies found, 1 otherwise
+ *
+ * For now checks for assembler '.incbin' directive, which could be
+ * part of inline assembly
+ */
+static int
+dcc_check_unsupported_directives(const char *cpp_fname, const char *input_fname)
+{
+    FILE *cpp_f = NULL;
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t bytes_read = 0;
+    int ret = 0;
+
+    cpp_f = fopen(cpp_fname, "r");
+    if (!cpp_f) {
+        rs_log_warning("failed to open preprocessed source %s", input_fname);
+	goto out;
+    }
+
+    while ((bytes_read = getline(&line, &len, cpp_f)) != -1) {
+        if (strstr(line, ".incbin \\\"") || strstr(line, ".incbin \"")) {
+	    rs_log_info("Found unsupported .incbin directive, compiling locally.");
+	    ret = 1;
+	    goto out;
+	}
+    }
+
+    if (bytes_read < 0 && errno != 0)
+        rs_log_warning("%s: getline failed: %s (%d), file %s", __func__, strerror(errno), errno, cpp_fname);
+out:
+    if (line)
+	free(line);
+    if (cpp_f)
+        fclose(cpp_f);
+    return ret;
+}
+
 
 /**
  * Pass a compilation across the network.
@@ -202,7 +246,8 @@ int dcc_compile_remote(char **argv,
                        pid_t cpp_pid,
                        int local_cpu_lock_fd,
                        struct dcc_hostdef *host,
-                       int *status)
+                       int *status,
+                       int *unsupported)
 {
     int to_net_fd = -1, from_net_fd = -1;
     int ret;
@@ -332,6 +377,12 @@ int dcc_compile_remote(char **argv,
      * cost of the ssh child. */
     if (ssh_pid) {
         dcc_collect_child("ssh", ssh_pid, &ssh_status, timeout_null_fd); /* ignore failure */
+    }
+
+    if (ret == 0 && *status != 0) {
+        if ((ret = dcc_check_unsupported_directives(cpp_fname, input_fname))) {
+            *unsupported = 1;
+        }
     }
 
     return ret;

--- a/src/remote.c
+++ b/src/remote.c
@@ -379,6 +379,10 @@ int dcc_compile_remote(char **argv,
         dcc_collect_child("ssh", ssh_pid, &ssh_status, timeout_null_fd); /* ignore failure */
     }
 
+    /* The compilation failed remotely: let's see if that was due to unsupported 
+     * directives in the source. It may be unobvious that we check this after trying
+     * remotely rather than before, but these are very rare, and scanning all the 
+     * preprocessed source has a cost. */
     if (ret == 0 && *status != 0) {
         if ((ret = dcc_check_unsupported_directives(cpp_fname, input_fname))) {
             *unsupported = 1;


### PR DESCRIPTION
A preprocessed source with `.incbin` assembler directive can not be compiled remotely.
As a result of remote compilation failure distcc marks the build node as unreliable (for no good reason).
This increases the build time, especially when there are only a few (2 -- 3) build nodes.
With this patch distcc checks for the `.incbin` directive and compiles such files locally.

To save a bit of time the check is done only on compilation error.
Files with `.incbin` directives are very rare, about 1 per 10000
(in Linux kernel there might be a handful of them, depending on config).
On the other hand preprocessed C sources are rather long (several MB).
Scanning ~ 10000 such files might be slower than running an extra remote compilation.
    
Changes since v1:
- dcc_compile_remote: check for unsupported directives only on error
- dcc_check_unsupported_directives: don't assign errno
