### PR TITLE
Fix manual for DISTCC_NO_REWRITE_CROSS

### DIFF
--- a/man/distcc.1
+++ b/man/distcc.1
@@ -776,7 +776,7 @@ variable is set to 0 then fallbacks are disabled and those
 compilations will simply fail.  Note that this does not affect jobs
 which must always be local such as linking.
 .TP
-.B "DISTCC_NO_CROSS_REWRITE"
+.B "DISTCC_NO_REWRITE_CROSS"
 By default distcc will rewrite calls gcc to use fully qualified names
 (like x86_64-linux-gnu-gcc), and clang to use the -target option. Setting this
 turns that off.


### PR DESCRIPTION
The manual currently mentions the environment variable `DISTCC_NO_CROSS_REWRITE` https://github.com/distcc/distcc/blob/2d33649380fafbc278a274ec0339c211b83744cd/man/distcc.1#L779

However the environment variable that is actually checked is `DISTCC_NO_REWRITE_CROSS` https://github.com/distcc/distcc/blob/2d33649380fafbc278a274ec0339c211b83744cd/src/compile.c#L726

This was mentioned here <https://github.com/distcc/distcc/issues/412#issuecomment-895949625>, but no one seemed to have noticed (?)