### PR TITLE
Support cross compilation when compiler given as path

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -550,9 +550,10 @@ static void dcc_add_clang_target(char **argv)
 {
         /* defined by autoheader */
     const char *target = NATIVE_COMPILER_TRIPLE;
+    const char *basename = dcc_find_basename(argv[0]);
 
-    if (strcmp(argv[0], "clang") == 0 || strncmp(argv[0], "clang-", strlen("clang-")) == 0 ||
-        strcmp(argv[0], "clang++") == 0 || strncmp(argv[0], "clang++-", strlen("clang++-")) == 0)
+    if (strcmp(basename, "clang") == 0 || strncmp(basename, "clang-", strlen("clang-")) == 0 ||
+        strcmp(basename, "clang++") == 0 || strncmp(basename, "clang++-", strlen("clang++-")) == 0)
         ;
     else
         return;
@@ -581,9 +582,10 @@ static int dcc_gcc_rewrite_fqn(char **argv)
     char *newcmd, *t, *path;
     int pathlen = 0;
     int newcmd_len = 0;
+    const char *basename = dcc_find_basename(argv[0]);
 
-    if (strcmp(argv[0], "gcc") == 0 || strncmp(argv[0], "gcc-", strlen("gcc-")) == 0 ||
-        strcmp(argv[0], "g++") == 0 || strncmp(argv[0], "g++-", strlen("g++-")) == 0)
+    if (strcmp(basename, "gcc") == 0 || strncmp(basename, "gcc-", strlen("gcc-")) == 0 ||
+        strcmp(basename, "g++") == 0 || strncmp(basename, "g++-", strlen("g++-")) == 0)
         ;
     else
         return -ENOENT;
@@ -599,7 +601,7 @@ static int dcc_gcc_rewrite_fqn(char **argv)
 
 
     strcat(newcmd, "-");
-    strcat(newcmd, argv[0]);
+    strcat(newcmd, basename);
 
     /* TODO, is this the right PATH? */
     path = getenv("PATH");


### PR DESCRIPTION
distcc supports cross compilation by rewriting the compiler binary (for GCC) or adding the `-target` flag (for Clang). However, this currently only works when the compiler is given without a full path. That is, when the compiler is given as, for example, `/usr/bin/gcc`, nothing gets rewritten.

This patch adds support for full paths by by matching on the compiler's basename instead of its full path in `argv[0]`.

The implementation in this patch rewrites paths as follows:
- `/path/to/clang` -> `/path/to/clang -target ...`
- `/path/to/gcc` -> `<target>-gcc`

I'm not quite sure if this difference in behavior between GCC and Clang is wanted. In particular, it might be better to rewrite the GCC case to `/path/to/<target>-gcc`. However,this would make the implementation a bit more complex so I'd like to discuss this before implementing it.