### PR TITLE
Add setuptools dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -14,7 +14,7 @@ QUICK SUMMARY
 
 0. Install prerequisites.  For example, on Debian or Ubuntu, you could use
 
-      sudo apt-get install gcc make python3 python3-dev libiberty-dev autoconf
+      sudo apt-get install gcc make python3 python3-dev python3-setuptools libiberty-dev autoconf
 
 1. Build and install
 


### PR DESCRIPTION
When follow the INSTALL file to install distcc, make command will fail by:

ModuleNotFoundError: No module named 'setuptools'
make: *** [Makefile:586: include-server] Error 1

Which should since #493.