### PR TITLE
Install popt from OSes in CI

### DIFF
--- a/.github/workflows/c-build.yml
+++ b/.github/workflows/c-build.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: ConorMacBride/install-package@v1
         with:
           # aclocal is in homebrew automake
-          brew: automake
+          brew: automake popt
           # brew-cask: TODO
-          apt: python3-dev libiberty-dev clang libavahi-client-dev
+          apt: python3-dev libiberty-dev clang libavahi-client-dev libpopt-dev
           # choco: TODO
           # TODO(#507): Install gdb when the tests pass
       - run: python3 -m pip install --upgrade setuptools


### PR DESCRIPTION
The old in-tree version seems to trip gcc errors. Probably there's not much point shipping a copy?