### PR TITLE
Fix a compile warning

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -638,7 +638,7 @@ static int dcc_get_proc_meminfo_mem_available(FILE* f) {
 
     char key[128];
     long value;
-    char unit[4];
+    char unit[5];
     char magnitude;
 
     if (f == NULL)


### PR DESCRIPTION
> ```
> src/util.c:648:56: error: 'sscanf' may overflow; destination buffer
> in argument 5 has size 4, but the corresponding specifier may require
> size 5 [-Werror,-Wfortify-source]
>
>   648 |         if (sscanf(line, "%127s %ld %4s", key, &value, unit) != 3)
>       |                                                        ^
> 1 error generated.
> ```