### PR TITLE
distccd: Fix comp_dir path rewrite under pump in DWARF 5

### DIFF
--- a/src/fix_debug_info.c
+++ b/src/fix_debug_info.c
@@ -400,6 +400,8 @@ static int update_debug_info(const char *path, const char *search,
 
   update_section(path, base, st.st_size, ".debug_info", search, replace);
   update_section(path, base, st.st_size, ".debug_str", search, replace);
+  /* DWARF 5+ puts the DW_AT_comp_dir string in .debug_line_str */
+  update_section(path, base, st.st_size, ".debug_line_str", search, replace);
 
   return munmap_file(base, path, fd, &st);
 }

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1356,9 +1356,7 @@ class Gdb_Case(CompileHello_Case):
             " -g -E -I.. -c ../%s | grep `pwd` >/dev/null" %
             self.sourceFilename())
         gcc_preprocessing_preserves_pwd = (error_rc == 0)
-        # NOTE(mbp 2025-01): Pump mode seems to always lose the full path to the file, for
-        # reasons I don't currently understand, so just don't test it in pump mode.
-        if (not pump_mode) and gcc_preprocessing_preserves_pwd:
+        if gcc_preprocessing_preserves_pwd:
             out, errs = self.runcmd("gdb -nh --batch --command=../gdb_commands "
                                     "./%s </dev/null" % testtmp_exe)
             if errs and errs not in ignorable_error_messages:


### PR DESCRIPTION
In pump mode, we need to fix up the DW_AT_comp_dir to remove the /tmp prefix that distccd uses. This is done by replacing the whole prefix with slashes ("/") in a clever abuse of the fact that ///foo/bar == /foo/bar on unix systems (which conveniently allows changing the ELF file in place without any need to shuffle offsets).

Up until DWARF 5, searching for the path prefix in the debug_str and debug_info sections were sufficient. However, with DWARF 5 (the default past gcc 11 [1]), the comp dir appears to be in the new debug_line_str section:

```
$ echo 'int main() { return 42; }' | cc -gdwarf-5 -c -xc - -o /tmp/test.o
$ readelf -p .debug_str -p .debug_line_str /tmp/test.o

String dump of section '.debug_str':
  [     0]  GNU C17 12.2.0 -mtune=generic -march=x86-64 -gdwarf-5 -fasynchronous-unwind-tables
  [    53]  main

String dump of section '.debug_line_str':
  [     0]  /tmp  <-- HERE
  [     5]  <stdin>
  [     d]  /tmp
  [    12]  <stdin>
  [    1a]  <stdin>
```

vs DWARF 4:

```
$ readelf -p .debug_str -p .debug_line_str /tmp/test.o
readelf: Warning: Section '.debug_line_str' was not dumped because it does not exist

String dump of section '.debug_str':
  [     0]  /tmp
  [     5]  <stdin>
  [     d]  GNU C17 12.2.0 -mtune=generic -march=x86-64 -gdwarf-4 -fasynchronous-unwind-tables
  [    60]  main
```

This patch updates distccd to fixup paths in the new section (if it exists), which fixes the failing Gdb_Case* tests.

Fixes: distcc/distcc#507

[1]: https://gcc.gnu.org/gcc-11/changes.html
[2]: https://github.com/distcc/distcc/commit/68be2b3bdb85f706c0e0ccd3245005c5d100f386

## Testing Done

- On Debian 12, `make check` passes with gdb installed (should unblock #508 )
- Manually confirmed dwarf 4 and dwarf 5 both work:

```
# in one shell
$ distccd -p 8080 --no-detach --verbose --log-file /tmp/dlog --enable-tcp-insecure --allow 127.0.0.1

# in another
$ cd /tmp
$ echo 'int main() { return 0; }' > foo.c
$ export DISTCC_FALLBACK=0
$ export DISTCC_VERBOSE=1
$ export DISTCC_HOSTS=127.0.0.1:8080,lzo,cpp

# check dwarf 4 to make sure non-existent section is a no-op
$ pump distcc cc -g -gdwarf-4 -c foo.c -o foo.o
$ readelf -Wwi foo.o | grep comp_dir
    <15>   DW_AT_comp_dir    : (strp) (offset: 0): ////////////////////tmp

# check dwarf5 (default)
$ pump distcc cc -g -gdwarf-5 -c foo.c -o foo.o
$ readelf -Wwi foo.o | grep comp_dir
    <16>   DW_AT_comp_dir    : (line_strp) (offset: 0): ////////////////////tmp

# restart distccd with master branch just to confirm bug
$ pump distcc cc -g -gdwarf-5 -c foo.c -o foo.o
$ readelf -Wwi foo.o | grep comp_dir
    <16>   DW_AT_comp_dir    : (line_strp) (offset: 0): /tmp/distccd_oAzWzS/tmp
```