### PR TITLE
tests: Fix NoDetachDaemon_Case leaving zombies around

### DIFF
--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1578,7 +1578,12 @@ class NoDetachDaemon_Case(CompileHello_Case):
             time.sleep(0.2)
 
     def killDaemon(self):
-        os.kill(self.pid, signal.SIGTERM)
+        # Terminate the process specified by the pidfile.  That should kill
+        # the distccd process, any child distccd processes and the shell
+        # process used to launch distccd.
+        daemon_pid = int(open(self.daemon_pidfile, 'rt').read())
+        os.kill(daemon_pid, signal.SIGTERM)
+
         pid, ret = os.wait()
         self.assert_equal(self.pid, pid)
 


### PR DESCRIPTION
This test uses a helper `runcmd_background` which launches distccd with --no-detach via a shell process (`sh -c`). It then saves off the *sh* pid and kills that. Given that the distccd process resets its process group, the SIGTERM only goes to sh, and distccd becomes a child of init (continuing to run indefinitely).

This causes even greater confusion because subsequent tests "succeed" by compiling using the zombies from past runs (even though the distccd.log files show that the current distccd is failing to start).

To make matters even more confusing, this failure is shell dependent. bash treats `-c 'foo'` as "exec foo" (so the pid returned is the pid of foo) while dash treats it as "fork and exec", so the pid returned is the pid of dash.

```
$ bash -c 'sleep 1' & pstree -p $$
[1] 20191
bash(20139)─┬─pstree(20192)
            └─sleep(20191)

$ dash -c 'sleep 1' & pstree -p $$
[1] 20193
bash(20139)─┬─dash(20193)───sleep(20195)
            └─pstree(20194)
```

We noticed this in our CI, which was hanging waiting for all processes to exit.

Fixes: distcc/distcc#129

## Testing done

- `make check` passes on Debian 12

Note: this possibly is related to #522 but I can't reproduce that failure to confirm