### PR TITLE
include_server: Fix file compression for unicode files

### DIFF
--- a/include_server/compress_files.py
+++ b/include_server/compress_files.py
@@ -98,7 +98,7 @@ class CompressFiles(object):
           # change its name.
           prefix = ""
         try:
-          real_file_fd = open(realpath, "r", encoding='latin-1')
+          real_file_fd = open(realpath, "rb")
         except (IOError, OSError) as why:
           sys.exit("Could not open '%s' for reading: %s" % (realpath, why))
         try:
@@ -108,7 +108,7 @@ class CompressFiles(object):
         try:
           new_filepath_fd.write(
             distcc_pump_c_extensions.CompressLzo1xAlloc(
-              prefix + real_file_fd.read()))
+              prefix.encode() + real_file_fd.read()))
         except (IOError, OSError) as why:
           sys.exit("Could not write to '%s': %s" % (new_filepath, why))
         new_filepath_fd.close()

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+# coding=utf-8
 
 # Copyright (C) 2002, 2003, 2004 by Martin Pool <mbp@samba.org>
 # Copyright 2007 Google Inc.
@@ -1605,6 +1606,22 @@ class ImplicitCompiler_Case(CompileHello_Case):
             CompileHello_Case.runtest (self)
 
 
+class Unicode_Case(Compilation_Case):
+    """Check unicode compression works OK in include_server"""
+    def source(self):
+        return """
+#include <stdio.h>
+
+int main(void) {
+    puts("Unicode is hard! 😭");
+    return 0;
+}
+"""
+
+    def checkBuiltProgramMsgs(self, msgs):
+        self.assert_equal(msgs, "Unicode is hard! 😭\n")
+
+
 class DashD_Case(Compilation_Case):
     """Test preprocessor arguments"""
     def source(self):
@@ -2277,6 +2294,7 @@ tests = [
          HostFile_Case,
          AbsSourceFilename_Case,
          Getline_Case,
+         Unicode_Case,
          # slow tests below here
          Concurrent_Case,
          HundredFold_Case,


### PR DESCRIPTION
compress_file.py used to read in the target files as latin-1, which will degrade the contents of unicode characters. This behavior was added in this commit [1] to suppress the UnicodeDecodeErrors.

This causes a build failure when a unicode character is outside a string (i.e. a BOM), and causes build inconsistency when compiling strings with unicode (silently compiling "successfully" but mangling the characters).

This commit fixes the mangling of unicode characters by reading the file in as a binary file prior to compressing it.

Note that opening as utf-8 is not a solution, as files may be in ISO-8859 encoding, causing the read to fail.

Tests added to ensure that the behavior works (reading as latin-1 causes the new test case to fail).

[1]: 23d362910b1a6b2dca8a8d49e84620dce7a1345a

Fixes: distcc/distcc#481
Fixes: distcc/distcc#515