### PR TITLE
include_server: Increase the limit of incoming connections

### DIFF
--- a/include_server/include_server.py
+++ b/include_server/include_server.py
@@ -44,10 +44,10 @@ import include_analyzer_memoizing_node
 import statistics
 
 # The default size passed to listen by a streaming socket server of
-# socketserver is only 5. Make it 128 (which appears to be the hard
-# built-in limit for Linux). This enables requests to the include
-# server to be buffered better.
-REQUEST_QUEUE_SIZE = 128
+# socketserver is only 5. Make it 4096, which is the default net.core.somaxconn
+# setting as of Linux 5.4. This enables requests to the include server to be
+# buffered better before connections begin being refused. See also listen(2).
+REQUEST_QUEUE_SIZE = 4096
 
 Debug = basics.Debug
 DEBUG_TRACE = basics.DEBUG_TRACE


### PR DESCRIPTION
We are able to push up to 800 concurrent compiles with pump mode, but to do so it's necessary for the include_server to buffer requests instead of dropping them.

As of Linux 5.4 (released Nov 2019), the default maximum on Linux is 4096 (configured by `sysctl net.core.somaxconn`). Prior to 2.4.25, it was hardcoded as a constant `SOMAXCONN` to 128 (see also listen(2) [NOTES](https://www.man7.org/linux/man-pages/man2/listen.2.html#NOTES)).

This patch aligns the include_server default with Linux's maximum. It should be safe on older versions and macOS which may have a lower maximum, as the behavior of listen(2) is to silently cap at the minimum of the requested backlog and the maximum setting.