### PR TITLE
include_server: Avoid evaluating None macro definitions

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -748,6 +748,7 @@ pump-maintainer-check: pump include-server check_programs
 	  DISTCC_HOSTS='<invalid>,cpp,lzo' \
 	    "$(builddir)/pump" \
 	        $(MAKE) \
+	        PYTHONOPTIMIZE=0 \
 	        RESTRICTED_PATH="$(RESTRICTED_PATH)" \
 	        TESTDISTCC_OPTS="--pump $(TESTDISTCC_OPTS)" \
 	        distcc-maintainer-check; \

--- a/include_server/macro_eval.py
+++ b/include_server/macro_eval.py
@@ -369,7 +369,11 @@ def _EvalExprHelper(expr, symbol_table, disabled):
       # args with parentheses.
       if symbol not in disabled:
         for definition in defs:
-          _EvalMacro(definition, disabled)
+          # We see None definitions for empty #defines (like include-guards)
+          # These won't expand to a value that would be in an #include, so
+          # we can safely skip them
+          if definition is not None:
+            _EvalMacro(definition, disabled)
       return value_set
 
 

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1623,6 +1623,31 @@ int main(void) {
         self.assert_equal(msgs, "hello DashD\n")
 
 
+class EmptyDefine_Case(Compilation_Case):
+    """
+    This test validates that empty definitions don't break the include_server
+    even when they share the same name as a real header.
+    """
+    def source(self):
+        return """
+#include <stdio.h>
+
+#define testhdr
+
+#define str(x) #x
+#include str(testhdr.h)
+
+int main(void) {
+    printf("%s\\n", "hello world");
+    return 0;
+}
+"""
+
+    def checkBuiltProgramMsgs(self, msgs):
+        self.assert_equal(msgs, "hello world\n")
+
+
+
 class DashMD_DashMF_DashMT_Case(CompileHello_Case):
     """Test -MD -MFfoo -MTbar"""
 
@@ -2272,6 +2297,7 @@ tests = [
          NoDetachDaemon_Case,
          SBeatsC_Case,
          DashD_Case,
+         EmptyDefine_Case,
          DashWpMD_Case,
          BinFalse_Case,
          BinTrue_Case,


### PR DESCRIPTION
It's possible that the macro definition is None (representing an empty
definition, such as from an include guard). In these cases, we do not
want to call _EvalMacro on them, as it violates the `assert` that the
definition should be a string or a tuple (caught with PYTHONOPTIMIZE=0).

A new test case enforces this, with a change to the Makefile to turn
python asserts on.

This should be safe in all cases because null definitions should not be
used in an #include (which is of course what we ultimately care about).
