### PR TITLE
ci: Fix test failures on macOS (pin back python3.13)

### DIFF
--- a/.github/workflows/c-build.yml
+++ b/.github/workflows/c-build.yml
@@ -19,14 +19,14 @@ jobs:
         with:
           # Note: aclocal is packaged with automake in Homebrew, so we need it
           # even though we don't use automake.
-          brew: autoconf automake popt python python3 python-setuptools
+          brew: autoconf automake popt python@3.13 python-setuptools
           # Note: no gdb on macOS because it's apparently not supported on arm64
           apt: clang libavahi-client-dev libpopt-dev gdb python3-dev python3-setuptools
           # brew-cask: TODO
           # choco: TODO
-      - run: which python3
+      - run: which python3.13 || which python3
       - run: ./autogen.sh
-      # Setting `python3` helps it find the Homebrew Python on macOS.
-      - run: ./configure PYTHON=python3
+      # python3 on macOS is 3.14, which breaks CI for unknown reasons, so we pin it back
+      - run: ./configure PYTHON="$(which python3.13 || which python3)"
       - run: make
       - run: make check

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1016,7 +1016,7 @@ class BackslashInMacro_Case(ComputedInclude_Case):
 #include <stdio.h>
 #if FALSE
   #define HEADER MAKE_HEADER(testhdr)
-  #define MAKE_HEADER(header_name) STRINGIZE(foobar\)
+  #define MAKE_HEADER(header_name) STRINGIZE(foobar\\)
   #define STRINGIZE(x) STRINGIZE2(x)
   #define STRINGIZE2(x) #x
 #else
@@ -1044,7 +1044,7 @@ class BackslashInFilename_Case(ComputedInclude_Case):
         return """
 #include <stdio.h>
 #define HEADER MAKE_HEADER(testhdr)
-#define MAKE_HEADER(header_name) STRINGIZE(subdir\header_name.h)
+#define MAKE_HEADER(header_name) STRINGIZE(subdir\\header_name.h)
 #define STRINGIZE(x) STRINGIZE2(x)
 #define STRINGIZE2(x) #x
 #include HEADER


### PR DESCRIPTION
Last week python3.14 was released and I'm reasonably certain that it's the reason the CI is failing on macOS:

- Last [success]: 3.13
- First [failure]: 3.14

As far as I can tell, 3.14 seems to work fine on Linux (tested in a
Docker python3.14-trixie container), so it's unclear why macOS
is failing. There is one small warning about a bad escape in
testdistcc.py, but its unrelated (and fixing it doesn't fix CI).

[success]: https://github.com/distcc/distcc/actions/runs/18382357021/job/52371897301
[failure]: https://github.com/distcc/distcc/actions/runs/18410284800/job/52460535426