### PR TITLE
distccd: Handle NULL from strsignal

### DIFF
--- a/src/dsignal.c
+++ b/src/dsignal.c
@@ -123,7 +123,13 @@ static void dcc_daemon_terminate(int whichsig)
     /* syslog is not safe from a signal handler */
     if (am_parent && !rs_trace_syslog) {
 #ifdef HAVE_STRSIGNAL
-        rs_log_info("%s", strsignal(whichsig));
+        char *signame = strsignal(whichsig);
+        /* on macOS, strsignal can return NULL */
+        if (signame != NULL) {
+            rs_log_info("terminated by signal %s", signame);
+        } else {
+            rs_log_info("terminated by signal %d", whichsig);
+        }
 #else
         rs_log_info("terminated by signal %d", whichsig);
 #endif


### PR DESCRIPTION
`strsignal` can return NULL on non-Linux platforms.  This patch gates the usage of strsignal in distccd's signal handler to handle this case gracefully.

Without this patch, it's possible that distccd will crash in the signal handler, which can cause it to fail to clean up children.

---

This is an older patch we had kicking around with a note that it was leaving hanging child processes on macOS; I can't reproduce the behavior anymore, and I'm pretty sure the root cause was #548 instead of strsignal, but it can't hurt to be a bit more cautious here (the man page confirms a NULL is returned when out of memory or for an unrecognized signal).