### PR TITLE
Remove signal-unsafe functions from handlers to avoid crash

### DIFF
--- a/src/distcc.c
+++ b/src/distcc.c
@@ -131,11 +131,7 @@ static void dcc_client_signalled (int whichsig)
 {
     signal(whichsig, SIG_DFL);
 
-#ifdef HAVE_STRSIGNAL
-    rs_log_info("%s", strsignal(whichsig));
-#else
-    rs_log_info("terminated by signal %d", whichsig);
-#endif
+    dcc_log_signal_termination(whichsig);
 
     dcc_cleanup_tempfiles_from_signal_handler();
 

--- a/src/dsignal.c
+++ b/src/dsignal.c
@@ -120,19 +120,8 @@ static void dcc_daemon_terminate(int whichsig)
 
     am_parent = getpid() == dcc_master_pid;
 
-    /* syslog is not safe from a signal handler */
-    if (am_parent && !rs_trace_syslog) {
-#ifdef HAVE_STRSIGNAL
-        char *signame = strsignal(whichsig);
-        /* on macOS, strsignal can return NULL */
-        if (signame != NULL) {
-            rs_log_info("terminated by signal %s", signame);
-        } else {
-            rs_log_info("terminated by signal %d", whichsig);
-        }
-#else
-        rs_log_info("terminated by signal %d", whichsig);
-#endif
+    if (am_parent) {
+        dcc_log_signal_termination(whichsig);
     }
 
     dcc_cleanup_tempfiles_from_signal_handler();

--- a/src/trace.c
+++ b/src/trace.c
@@ -448,3 +448,29 @@ void dcc_job_summary_append(const char *s) {
     if (len > 0)
         strncat(job_summary, s, len);
 }
+
+/* all logger_list loggers are unsafe in a signal handler due to printf(3); */
+void
+dcc_log_signal_termination(int whichsig)
+{
+    char buf[64];
+    size_t len;
+    ssize_t ret;
+    if (whichsig > 63 || whichsig < 0) {
+        strcpy(buf, "terminated by unknown signal");
+        len = strlen(buf);
+    } else {
+        strcpy(buf, "terminated by signal ");
+        len = strlen(buf);
+        if (whichsig > 9)
+            buf[len++] = (whichsig / 10) + '0';
+        buf[len++] = (whichsig % 10) + '0';
+    }
+
+    strcpy(&buf[len], "\n");
+
+    ret = write(STDERR_FILENO, buf, len + 1);
+    if (ret == -1) {
+        /* nothing to do here, exiting anyways; needed for -Wunused-result */
+    }
+}

--- a/src/trace.h
+++ b/src/trace.h
@@ -231,3 +231,4 @@ extern const char *rs_program_name;
 void dcc_job_summary_clear(void);
 void dcc_job_summary(void);
 void dcc_job_summary_append(const char *s);
+void dcc_log_signal_termination(int);


### PR DESCRIPTION
As discussed in #563, we're seeing the distccd daemon routinely crashing in CI due to calling signal unsafe functions in signal handlers.

I've reproduced the crash locally, seeing it crash on both `strsignal(3)` as well as `rs_log_info` (due to its use of `sprintf(3)`).

It appears there was already a calculated choice to run the risk of tracing in the handler, per the comment in cleanup.c:

     * If from_signal_handler (a boolean) is non-zero, it means that
     * we're being called from a signal handler, so we need to be
     * careful not to call malloc() or free() or any other functions
     * that might not be async-signal-safe.
     * (We do call the tracing functions, which is perhaps unsafe
     * because they call sprintf() if DISCC_VERBOSE=1 is enabled.
     * But in that case it is probably worth the very small risk
     * of a crash to get the full tracing output.)

It's unclear if we still want to take this risk (I've never witnessed a problem on Linux) or what the breakdown of macOS crashes due to strsignal vs sprintf might be, but the easiest way to move the needle for now without losing logging entirely is to disable strsignal on all platforms in signal handlers.

---

**UPDATE:** sprintf was a problem too, so I've updated the PR to remove all unsafe functions and do a best-effor logging of just the bare minimum (the signal number that terminated the program) to stderr.

Fixes #563 