### PR TITLE
ci: Set shorter timeout on GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   action-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Check workflow files

--- a/.github/workflows/c-build.yml
+++ b/.github/workflows/c-build.yml
@@ -13,6 +13,7 @@ jobs:
         - ubuntu-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: ConorMacBride/install-package@v1


### PR DESCRIPTION
The build finishes in 4m on both mac and ubuntu when there's no failures. A recent [action] somehow hung though, running for 6hr before timing out.

To avoid spending credits, this patch ratchets down the CI time to 15m which should be plenty future proof while also setting a much more reasonable limit than the [default] 360.

[action]: https://github.com/distcc/distcc/actions/runs/18975209355
[default]: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes