### PR TITLE
Strip -x flag when compiling preprocessed files remotely

### DIFF
--- a/src/strip.c
+++ b/src/strip.c
@@ -57,6 +57,12 @@
  * passed directly to cpp.  When given to gcc they have different
  * meanings.
  *
+ * We also strip the -x flag, which specifies the source language.
+ * When compiling preprocessed files (.ii, .mi, etc.), the -x flag
+ * causes GCC to ignore line directives and record the temporary
+ * preprocessed filename in debug info instead of the original source.
+ * The file extension is sufficient for GCC to identify the language.
+ *
  * The value stored in '*out_argv' is malloc'd, but the arguments that
  * are pointed to by that array are aliased with the values pointed
  * to by 'from'.  The caller is responsible for calling free() on
@@ -94,7 +100,8 @@ int dcc_strip_local_args(char **from, char ***out_argv)
             || str_equal("-isystem", from[from_i])
             || str_equal("-iwithprefixbefore", from[from_i])
             || str_equal("-idirafter", from[from_i])
-            || str_equal("-Xpreprocessor", from[from_i])) {
+            || str_equal("-Xpreprocessor", from[from_i])
+            || str_equal("-x", from[from_i])) {
             /* skip next word, being option argument */
             if (from[from_i+1])
                 from_i++;
@@ -110,8 +117,9 @@ int dcc_strip_local_args(char **from, char ***out_argv)
                  || str_startswith("-MT", from[from_i])
                  || str_startswith("-MQ", from[from_i])
                  || str_startswith("-isystem", from[from_i])
-                 || str_startswith("-stdlib", from[from_i])) {
-            /* Something like "-DNDEBUG" or
+                 || str_startswith("-stdlib", from[from_i])
+                 || str_startswith("-x", from[from_i])) {
+            /* Something like "-DNDEBUG" or "-xc++" or
              * "-Wp,-MD,.deps/nsinstall.pp".  Just skip this word */
             ;
         }

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -478,6 +478,14 @@ class StripArgs_Case(SimpleDistCC_Case):
                  # New options stripped in 0.11
                  ("cc -o nsinstall.o -c -DOSTYPE=\"Linux2.4\" -DOSARCH=\"Linux\" -DOJI -D_BSD_SOURCE -I../dist/include -I../dist/include -I/home/mbp/work/mozilla/mozilla-1.1/dist/include/nspr -I/usr/X11R6/include -fPIC -I/usr/X11R6/include -Wall -W -Wno-unused -Wpointer-arith -Wcast-align -pedantic -Wno-long-long -pthread -pipe -DDEBUG -D_DEBUG -DDEBUG_mbp -DTRACING -g -I/usr/X11R6/include -include ../config-defs.h -DMOZILLA_CLIENT -Wp,-MD,.deps/nsinstall.pp nsinstall.c",
                   "cc -o nsinstall.o -c -fPIC -Wall -W -Wno-unused -Wpointer-arith -Wcast-align -pedantic -Wno-long-long -pthread -pipe -g nsinstall.c"),
+
+                 # Test -x flag stripping
+                 ("gcc -x c++ -g -std=c++17 -c hello.ii -o hello.o",
+                  "gcc -g -std=c++17 -c hello.ii -o hello.o"),
+                 ("g++ -xc++ -g -c hello.ii -o hello.o",
+                  "g++ -g -c hello.ii -o hello.o"),
+                 ("gcc -xobjective-c++ -g -c hello.mii -o hello.o",
+                  "gcc -g -c hello.mii -o hello.o"),
                  )
         for cmd, expect in cases:
             o, err = self.runcmd("h_strip %s" % cmd)


### PR DESCRIPTION
Fixes debug info bug with CMake CMP0119 (CMake 3.20+)

When CMake policy CMP0119 is enabled, CMake adds the -x flag to explicitly specify the source language (e.g., -x c++). When distcc preprocesses locally and sends .ii files to remote servers with the -x flag present, GCC ignores line directives in the preprocessed file and records the temporary filename (e.g., /tmp/distccd_XXXXX.ii) in DWARF debug info instead of the original source path.

This breaks debugger source resolution, as the debug info points to non-existent temporary files rather than the actual source files.

Solution:
Strip the -x flag (both "-x <lang>" and "-x<lang>" formats) in dcc_strip_local_args() when sending preprocessed files to remote servers. The file extension (.ii, .mi, .mii, etc.) is sufficient for GCC to identify the language, and without -x, GCC correctly honors line directives and preserves original source paths in debug info.

Changes:
- src/strip.c: Add -x to the list of flags stripped for remote compilation
- test/testdistcc.py: Add test cases for -x flag stripping