### PR TITLE
distccd: honor tcp include option ordering

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -300,6 +300,7 @@ h_scanargs_obj = src/h_scanargs.o $(common_obj)
 h_hosts_obj = src/h_hosts.o $(common_obj)
 h_argvtostr_obj = src/h_argvtostr.o $(common_obj)
 h_strip_obj = src/h_strip.o $(common_obj) src/strip.o
+h_dopt_obj = src/h_dopt.o $(common_obj) src/dopt.o src/access.o
 h_parsemask_obj = src/h_parsemask.o $(common_obj) src/access.o
 h_sa2str_obj = src/h_sa2str.o $(common_obj) src/srvnet.o src/access.o
 h_ccvers_obj = src/h_ccvers.o $(common_obj)
@@ -322,7 +323,8 @@ SRC =	src/stats.c							\
 	src/daemon.c src/distcc.c src/dsignal.c				\
 	src/dopt.c src/dparent.c src/exec.c src/filename.c		\
 	src/h_argvtostr.c						\
-	src/h_exten.c src/h_hosts.c src/h_issource.c src/h_parsemask.c	\
+	src/h_dopt.c src/h_exten.c src/h_hosts.c src/h_issource.c	\
+	src/h_parsemask.c						\
 	src/h_sa2str.c src/h_scanargs.c src/h_strip.c			\
 	src/h_dotd.c src/h_compile.c src/h_getline.c			\
 	src/help.c src/history.c src/hosts.c src/hostfile.c		\
@@ -411,6 +413,7 @@ sbin_PROGRAMS = \
 
 check_PROGRAMS = \
 	h_argvtostr@EXEEXT@ \
+	h_dopt@EXEEXT@ \
 	h_exten@EXEEXT@ \
 	h_fix_debug_info@EXEEXT@ \
 	h_hosts@EXEEXT@ \
@@ -524,6 +527,9 @@ h_parsemask@EXEEXT@: $(h_parsemask_obj)
 
 h_strip@EXEEXT@: $(h_strip_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_strip_obj) $(LIBS)
+
+h_dopt@EXEEXT@: $(h_dopt_obj)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_dopt_obj) $(LIBS)
 
 h_ccvers@EXEEXT@: $(h_ccvers_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_ccvers_obj) $(LIBS)

--- a/src/h_dopt.c
+++ b/src/h_dopt.c
@@ -58,6 +58,13 @@ static int check_tcp_insecure_order(const char *label,
     return 0;
 }
 
+#ifdef HAVE_GSSAPI
+/* The distccd test helper links dopt.c, which references dcc_auth_enabled when
+ * GSS-API support is enabled. Distcc helpers do not link the full server, so
+ * this symbol is provided locally for successful helper builds. */
+int dcc_auth_enabled = 0;
+#endif
+
 int main(int argc, char **argv) {
     const char *first_args[] = {
         "distccd",

--- a/src/h_dopt.c
+++ b/src/h_dopt.c
@@ -1,0 +1,89 @@
+/* -*- c-file-style: "java"; indent-tabs-mode: nil; tab-width: 4; fill-column: 78 -*-
+ *
+ * distcc -- A simple distributed compiler system
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <config.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "distcc.h"
+#include "dopt.h"
+
+const char *rs_program_name = __FILE__;
+const char *opt_user = "distcc";
+
+extern int opt_allow_private;
+
+int dcc_should_be_inetd(void);
+
+static void reset_options(void) {
+    opt_enable_tcp_insecure = 0;
+    opt_inetd_mode = 0;
+    opt_daemon_mode = 0;
+    opt_allow_private = 0;
+    opt_allowed = NULL;
+}
+
+int dcc_should_be_inetd(void) {
+    return opt_inetd_mode;
+}
+
+static int check_tcp_insecure_order(const char *label,
+                                    const char **argv,
+                                    int argc) {
+    reset_options();
+
+    if (distccd_parse_options(argc, argv) != 0) {
+        fprintf(stderr, "%s: parser returned failure\n", label);
+        return 1;
+    }
+
+    if (!opt_enable_tcp_insecure) {
+        fprintf(stderr, "%s: --enable-tcp-insecure was not honored\n", label);
+        return 1;
+    }
+
+    if (!opt_inetd_mode) {
+        fprintf(stderr, "%s: --inetd was not honored\n", label);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    const char *first_args[] = {
+        "distccd",
+        "--enable-tcp-insecure",
+        "--inetd",
+        NULL
+    };
+    const char *last_args[] = {
+        "distccd",
+        "--inetd",
+        "--enable-tcp-insecure",
+        NULL
+    };
+
+    if (argc != 2 || strcmp(argv[1], "tcp-insecure-order") != 0) {
+        fprintf(stderr, "usage: %s tcp-insecure-order\n", argv[0]);
+        return 1;
+    }
+
+    if (check_tcp_insecure_order("first", first_args, 3) != 0) {
+        return 1;
+    }
+    if (check_tcp_insecure_order("last", last_args, 3) != 0) {
+        return 1;
+    }
+
+    puts("ok");
+    return 0;
+}

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -833,6 +833,13 @@ class DaemonBadPort_Case(SimpleDistCC_Case):
         self.assert_no_file("daemonpid.tmp")
 
 
+class TcpInsecureOptionOrder_Case(SimpleDistCC_Case):
+    def runtest(self):
+        """Test --enable-tcp-insecure is honored in different positions."""
+        out, err = self.runcmd("h_dopt tcp-insecure-order")
+        self.assert_equal(out.strip(), "ok")
+
+
 class InvalidHostSpec_Case(SimpleDistCC_Case):
     def runtest(self):
         """Test various invalid DISTCC_HOSTS

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -2363,6 +2363,7 @@ tests = [
          ExtractExtension_Case,
          ImplicitCompiler_Case,
          DaemonBadPort_Case,
+         TcpInsecureOptionOrder_Case,
          AccessDenied_Case,
          NoServer_Case,
          MixedServerPumpFallback_Case,


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Refs #580.

## Summary

Add focused regression coverage for `distccd` option-order parsing around `--enable-tcp-insecure` and `--inetd`.

## What This Actually Changes

Before this pull request, there was no focused regression test proving that `distccd` parses `--enable-tcp-insecure` the same way when it appears before or after `--inetd`.

That matters because users often do not start `distccd` by typing the final command by hand. The command line may be assembled by a systemd unit, an inetd configuration, a container entrypoint, a distribution package, or a local wrapper script. Those layers can place valid options in different orders while still expressing the same user intent.

For example, these two invocations should be equivalent:

```text
distccd --enable-tcp-insecure --inetd
distccd --inetd --enable-tcp-insecure
```

The expected parser result is the same in both cases:

```text
opt_enable_tcp_insecure = true
opt_inetd_mode = true
```

This pull request adds an executable check for that expectation. It introduces a small test helper that calls the existing option parser with both argument orders and fails if either option is lost.

For users, this does not add a new command-line option and does not change how `distccd` is normally started. The practical change is that future parser changes should now fail the test suite if they accidentally make this option order matter again.

## What this PR fixes

This pull request fixes a missing test coverage gap around `distccd` command-line option parsing. It makes the expected option-order behavior explicit in the test suite instead of leaving it as an assumption.

The current patch does not change the runtime parser implementation itself. It should therefore be treated as regression coverage for #580 unless a separate parser change is added or a failing baseline reproduction proves that the existing parser behavior is already covered by this test.

The specific behavior being protected is simple: if the command line contains both `--enable-tcp-insecure` and `--inetd`, both parser flags should be enabled regardless of which one appears first.

## What changed in code

`src/h_dopt.c` adds a small test helper for the existing `distccd_parse_options()` parser. The helper calls the parser twice with the same options in different orders:

```text
distccd --enable-tcp-insecure --inetd
distccd --inetd --enable-tcp-insecure
```

It then checks the internal parser state after each call:

```text
opt_enable_tcp_insecure = true
opt_inetd_mode = true
```

If a future parser change accidentally drops `--enable-tcp-insecure` in one order, the helper would detect a state like this and fail:

```text
opt_enable_tcp_insecure = false
opt_inetd_mode = true
```

`Makefile.in` builds the helper, and `test/testdistcc.py` registers `TcpInsecureOptionOrder_Case` so normal test runs can exercise this coverage.

## Why this matters for users

A user, package maintainer, or cluster operator may look at a service configuration and see that `--enable-tcp-insecure` is present. If parser behavior depended on option order, the visible command line could look correct while the daemon internally behaves as if that option was not enabled.

That difference is hard to diagnose from the outside. The daemon may still start, but the requested include-related daemon behavior may not match the configuration. In a distributed build setup, that can show up later as confusing pump, include transfer, or remote preprocessing behavior where one service wrapper works and another visually similar wrapper does not.

This is especially relevant for distcc because it is commonly run through wrappers, service managers, containers, and package-provided scripts. Those layers often reorder or append arguments while preserving the intended options. Equivalent option sets should produce equivalent daemon state.

Even though this pull request is test coverage, it protects that user-facing expectation by turning it into a repeatable regression test. Maintainers get a small, direct failure if future parser work makes these two valid command lines behave differently.

## Scope boundaries

This pull request currently adds regression coverage only. It does not change normal `distccd` runtime behavior and does not include release, container, RPM packaging, or unrelated Secure Shell warning fixes.

The originally reported option name `--enable-tcp-includes` is not present in the current source tree. The current daemon option is `--enable-tcp-insecure`; this pull request does not add or rename command-line options.

## Local Scope Evidence

The current branch only changes:

```text
Makefile.in
src/h_dopt.c
test/testdistcc.py
```

A direct diff check against `src/dopt.c` and `src/distccd.c` is empty. A scope check found no Docker, release workflow, RPM packaging, release-package helper, or `src/ssh.c` changes in this branch.

## Validation

Required before treating this as ready again:

```text
git diff --check
python3.13 -m py_compile test/testdistcc.py
./autogen.sh
PYTHON=/usr/bin/python3.13 ./configure --enable-Werror
make h_dopt
./h_dopt tcp-insecure-order
make TESTNAME=TcpInsecureOptionOrder_Case single-test
make check
local leak scan
```

## Changelog

I accidentally changed this pull request while testing release and packaging work. Those unrelated changes have been reversed, and the branch has been restored to the original intended scope: focused `distccd` option-order regression coverage only.