### PR TITLE
strip local include-search args from remote compile argv

### DIFF
--- a/src/strip.c
+++ b/src/strip.c
@@ -94,6 +94,7 @@ int dcc_strip_local_args(char **from, char ***out_argv)
             || str_equal("-isystem", from[from_i])
             || str_equal("-iwithprefixbefore", from[from_i])
             || str_equal("-idirafter", from[from_i])
+            || str_equal("-iquote", from[from_i])
             || str_equal("-Xpreprocessor", from[from_i])) {
             /* skip next word, being option argument */
             if (from[from_i+1])
@@ -110,6 +111,7 @@ int dcc_strip_local_args(char **from, char ***out_argv)
                  || str_startswith("-MT", from[from_i])
                  || str_startswith("-MQ", from[from_i])
                  || str_startswith("-isystem", from[from_i])
+                 || str_startswith("-iquote", from[from_i])
                  || str_startswith("-stdlib", from[from_i])) {
             /* Something like "-DNDEBUG" or
              * "-Wp,-MD,.deps/nsinstall.pp".  Just skip this word */

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -459,7 +459,7 @@ class CompilerOptionsPassed_Case(SimpleDistCC_Case):
 
 
 class StripArgs_Case(SimpleDistCC_Case):
-    """Test -D and -I arguments are removed"""
+    """Test local-only preprocessor arguments are removed"""
     def runtest(self):
         cases = (("gcc -c hello.c", "gcc -c hello.c"),
                  ("cc -Dhello hello.c -c", "cc hello.c -c"),
@@ -472,6 +472,8 @@ class StripArgs_Case(SimpleDistCC_Case):
                  ("cc -c -I ../include  hello.c", "cc -c hello.c"),
                  ("cc -c -I. -I.. -I../include -I/home/mbp/garnome/include -c -o foo.o foo.c",
                   "cc -c -c -o foo.o foo.c"),
+                 ("cc -c hello.c -iquote .", "cc -c hello.c"),
+                 ("cc -c hello.c -iquote.", "cc -c hello.c"),
                  ("cc -c -DDEBUG -DFOO=23 -D BAR -c -o foo.o foo.c",
                   "cc -c -c -o foo.o foo.c"),
 


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Fixes #582.
Refs #504.

## Summary

Strip local `-iquote` include-search arguments from the remote compile argument list after local preprocessing, matching the existing handling for `-I` and `-isystem`.

## What This Actually Changes

Before this pull request, distcc already stripped some local include-search arguments before sending an already-preprocessed compile job to a remote compiler. However, `-iquote` was not covered in the same way.

That matters because `-iquote` is useful while preprocessing source locally, but it is not useful when the remote compiler receives already-preprocessed input. Passing it to the remote compile step can make compilers such as Clang warn that the argument is unused.

This pull request makes `-iquote` follow the same remote-argument stripping path as the other local include-search options.

## What this PR fixes

This fixes the leak of local `-iquote` include-search arguments into the remote compile command.

For example, a user may run:

```text
distcc clang++ -iquote . -c x.cpp
```

After local preprocessing, the remote compile step should not still receive:

```text
-iquote .
```

The expected remote compile argument list keeps the actual compile inputs but drops the local include-search option that no longer affects preprocessed input.

If `-iquote` is left in the remote argv, Clang can emit an unused-command-line-argument warning. In projects that build with warnings as errors, that warning can turn a valid distributed compile into a failure.

## What changed in code

`src/strip.c` now treats both supported `-iquote` forms as local include-search arguments that should be removed from the remote compile argv after preprocessing:

```text
-iquote .
-iquote.
```

`test/testdistcc.py` extends the existing `StripArgs_Case` coverage so both forms are checked by the regression test.

## Why this matters for users

Users do not add `-iquote` for the remote compile step; they add it so the preprocessor can find project headers. Once preprocessing has already happened locally, sending that option to the remote compiler is at best unnecessary and at worst a warning source.

This is especially visible with Clang and strict build systems. A warning about an unused local include-search option can break builds that use `-Werror`, even though the source code and include paths are otherwise correct.

Dropping `-iquote` from the remote argv keeps the distributed compile command closer to what the remote compiler actually needs and avoids making local include-search settings leak into the wrong phase.

## Scope

This pull request is limited to `-iquote` remote argument stripping and focused regression coverage. It does not include release, container, RPM packaging, or unrelated Secure Shell warning fixes.

## Scope boundaries

This Pull Request is limited to remote compiler argument cleanup for local-only include-search options and the regression tests that prove those arguments are not sent to the remote compile command. It does not change compression behavior, distccd daemon startup, pump include-server behavior, release metadata, package files, or container files.

## Local Scope Evidence

The current branch only changes:

```text
src/strip.c
test/testdistcc.py
```

A scope check found no Docker, release workflow, RPM packaging, release-package helper, or `src/ssh.c` changes in this branch.

## Validation

Required before treating this as ready again:

```text
git diff --check
python3.13 -m py_compile test/testdistcc.py
./autogen.sh
PYTHON=/usr/bin/python3.13 ./configure --enable-Werror
make h_strip
./h_strip clang++ -iquote . -c x.cpp
./h_strip clang++ -iquote. -c x.cpp
make TESTNAME=StripArgs_Case single-test
make check
local leak scan
```

## Changelog

I accidentally changed this pull request while testing release and packaging work. Those unrelated changes have been reversed, and the branch has been restored to the original intended scope: stripping local `-iquote` arguments from the remote compile argv only.