### PR TITLE
ssh: preserve DISTCC_SSH options across connections

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -298,6 +298,7 @@ h_exten_obj = src/h_exten.o $(common_obj)
 h_issource_obj = src/h_issource.o $(common_obj)
 h_scanargs_obj = src/h_scanargs.o $(common_obj)
 h_hosts_obj = src/h_hosts.o $(common_obj)
+h_ssh_obj = src/h_ssh.o $(common_obj) src/ssh.o
 h_argvtostr_obj = src/h_argvtostr.o $(common_obj)
 h_strip_obj = src/h_strip.o $(common_obj) src/strip.o
 h_parsemask_obj = src/h_parsemask.o $(common_obj) src/access.o
@@ -322,7 +323,8 @@ SRC =	src/stats.c							\
 	src/daemon.c src/distcc.c src/dsignal.c				\
 	src/dopt.c src/dparent.c src/exec.c src/filename.c		\
 	src/h_argvtostr.c						\
-	src/h_exten.c src/h_hosts.c src/h_issource.c src/h_parsemask.c	\
+	src/h_exten.c src/h_hosts.c src/h_ssh.c			\
+	src/h_issource.c src/h_parsemask.c				\
 	src/h_sa2str.c src/h_scanargs.c src/h_strip.c			\
 	src/h_dotd.c src/h_compile.c src/h_getline.c			\
 	src/help.c src/history.c src/hosts.c src/hostfile.c		\
@@ -414,6 +416,7 @@ check_PROGRAMS = \
 	h_exten@EXEEXT@ \
 	h_fix_debug_info@EXEEXT@ \
 	h_hosts@EXEEXT@ \
+	h_ssh@EXEEXT@ \
 	h_issource@EXEEXT@ \
 	h_parsemask@EXEEXT@ \
 	h_sa2str@EXEEXT@ \
@@ -515,6 +518,9 @@ h_scanargs@EXEEXT@: $(h_scanargs_obj)
 
 h_hosts@EXEEXT@: $(h_hosts_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_hosts_obj) $(LIBS)
+
+h_ssh@EXEEXT@: $(h_ssh_obj)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_ssh_obj) $(LIBS)
 
 h_argvtostr@EXEEXT@: $(h_argvtostr_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_argvtostr_obj) $(LIBS)

--- a/src/h_ssh.c
+++ b/src/h_ssh.c
@@ -1,0 +1,117 @@
+/* -*- c-file-style: "java"; indent-tabs-mode: nil; tab-width: 4; fill-column: 78 -*-
+ *
+ * distcc -- A simple distributed compiler system
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+/**
+ * Test harness for ssh.c.
+ **/
+
+#include <config.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/wait.h>
+
+#include "distcc.h"
+#include "exitcode.h"
+#include "trace.h"
+#include "util.h"
+
+#define USAGE \
+"usage: h_ssh COMMAND\n" \
+"where\n" \
+"  COMMAND is repeat-env\n"
+
+const char *rs_program_name = "h_ssh";
+
+
+static int collect_ssh_child(pid_t ssh_pid)
+{
+    int status;
+    pid_t ret;
+
+    do {
+        ret = waitpid(ssh_pid, &status, 0);
+    } while (ret == -1 && errno == EINTR);
+
+    if (ret == -1) {
+        rs_log_error("waitpid failed: %s", strerror(errno));
+        return EXIT_IO_ERROR;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        rs_log_error("ssh command exited with status %d", status);
+        return EXIT_DISTCC_FAILED;
+    }
+
+    return 0;
+}
+
+
+static int run_connect_once(void)
+{
+    char user[] = "builduser";
+    char machine[] = "buildhost";
+    char path[] = "distccd";
+    int f_in = -1;
+    int f_out = -1;
+    int ret;
+    int close_ret = 0;
+    pid_t ssh_pid = 0;
+
+    ret = dcc_ssh_connect(NULL, user, machine, path, &f_in, &f_out, &ssh_pid);
+    if (ret != 0)
+        return ret;
+
+    if (f_out != -1 && dcc_close(f_out))
+        close_ret = EXIT_IO_ERROR;
+
+    ret = collect_ssh_child(ssh_pid);
+
+    if (f_in != -1 && dcc_close(f_in))
+        close_ret = EXIT_IO_ERROR;
+
+    if (ret != 0)
+        return ret;
+
+    return close_ret;
+}
+
+
+int main(int argc, char *argv[])
+{
+    int ret;
+
+    rs_add_logger(rs_logger_file, RS_LOG_DEBUG, NULL, STDERR_FILENO);
+
+    if (argc != 2) {
+        rs_log_error(USAGE);
+        return EXIT_BAD_ARGUMENTS;
+    }
+
+    if (strcmp(argv[1], "repeat-env") != 0) {
+        rs_log_error(USAGE);
+        return EXIT_BAD_ARGUMENTS;
+    }
+
+    if (!getenv("DISTCC_SSH")) {
+        rs_log_error("DISTCC_SSH must be set");
+        return EXIT_BAD_ARGUMENTS;
+    }
+
+    ret = run_connect_once();
+    if (ret != 0)
+        return ret;
+
+    return run_connect_once();
+}

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -198,12 +198,19 @@ int dcc_ssh_connect(char *ssh_cmd,
     char *child_argv[11+max_ssh_args];
     int i,j;
     int num_ssh_args = 0;
+    char *ssh_cmd_buf = NULL;
     char *ssh_cmd_in;
 
     /* We need to cast away constness.  I promise the strings in the argv[]
      * will not be modified. */
 
     if (!ssh_cmd && (ssh_cmd_in = getenv("DISTCC_SSH"))) {
+        ssh_cmd_buf = strdup(ssh_cmd_in);
+        if (!ssh_cmd_buf) {
+            rs_log_crit("failed to duplicate DISTCC_SSH");
+            return EXIT_OUT_OF_MEMORY;
+        }
+        ssh_cmd_in = ssh_cmd_buf;
         ssh_cmd = strtok(ssh_cmd_in, " ");
         char *token = strtok(NULL, " ");
         while (token != NULL) {
@@ -246,6 +253,7 @@ int dcc_ssh_connect(char *ssh_cmd,
     /*     child_argv[i++] = (char *) "--log-stderr"; */
 
     ret = dcc_run_piped_cmd(child_argv, f_in, f_out, ssh_pid);
+    free(ssh_cmd_buf);
 
     return ret;
 }

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -888,6 +888,34 @@ class ParseHostSpec_Case(SimpleDistCC_Case):
         assert out == expected, "expected %s\ngot %s" % (repr(expected), repr(out))
 
 
+class SecureShellCommandEnvironment_Case(SimpleDistCC_Case):
+    """Check that DISTCC_SSH options survive repeated Secure Shell connects."""
+    def runtest(self):
+        fake_ssh = os.path.abspath("fake-ssh")
+        fake_ssh_log = os.path.abspath("fake-ssh.log")
+
+        f = open(fake_ssh, "w")
+        try:
+            f.write("#!/bin/sh\n")
+            f.write("printf '%%s\\n' \"$*\" >> %s\n" % _ShellSafe(fake_ssh_log))
+        finally:
+            f.close()
+        os.chmod(fake_ssh, 0o700)
+
+        os.environ["DISTCC_SSH"] = "%s --distcc-test-option" % fake_ssh
+        self.runcmd("h_ssh repeat-env")
+
+        f = open(fake_ssh_log)
+        try:
+            lines = f.read().splitlines()
+        finally:
+            f.close()
+
+        expected = ("--distcc-test-option -l builduser buildhost distccd "
+                    "--inetd --enable-tcp-insecure")
+        self.assert_equal(lines, [expected, expected])
+
+
 class Compilation_Case(WithDaemon_Case):
     '''Test distcc by actually compiling a file'''
     def setup(self):
@@ -2361,6 +2389,7 @@ tests = [
          MixedServerPumpFallback_Case,
          InvalidHostSpec_Case,
          ParseHostSpec_Case,
+         SecureShellCommandEnvironment_Case,
          ImpliedOutput_Case,
          SyntaxError_Case,
          NoHosts_Case,


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Fixes #583.

## Summary

Preserve `DISTCC_SSH` options across repeated Secure Shell connections in the same distcc process.

## What This Actually Changes

Before this pull request, the Secure Shell connection path could tokenize the string returned by `getenv("DISTCC_SSH")` directly. Tokenizing modifies the string by inserting string terminators between arguments.

That is dangerous because environment strings returned by `getenv()` are process-owned storage. If the same distcc process opens more than one Secure Shell connection, the second connection may see a modified `DISTCC_SSH` value instead of the original command line.

This pull request changes the code to tokenize a copy of `DISTCC_SSH`. The environment value remains intact for later connections.

## What this PR fixes

This fixes repeated-connection behavior for custom Secure Shell commands.

For example, a user may configure:

```text
DISTCC_SSH="ssh -p 2222 -i /path/to/key"
```

The expected behavior is that every connection in the process keeps the same command and options:

```text
ssh -p 2222 -i /path/to/key host command
ssh -p 2222 -i /path/to/key host command
```

The wrong behavior is that the first tokenization can damage the stored environment value, so a later connection may effectively lose arguments such as the port or identity file:

```text
ssh host command
```

That can make one remote compile attempt work and a later one fail or connect with different authentication or transport settings.

## What changed in code

`src/ssh.c` now copies the `DISTCC_SSH` environment value before splitting it into arguments. The tokenization still produces the same Secure Shell argument vector, but it no longer mutates the process environment string.

`src/h_ssh.c` adds a focused regression helper that exercises repeated Secure Shell connection setup in one process. `Makefile.in` builds that helper, and `test/testdistcc.py` registers the regression test.

## Why this matters for users

Many distcc deployments use `DISTCC_SSH` for non-default Secure Shell behavior: custom ports, jump hosts, identity files, wrappers, or extra transport options.

Those options are often required for the remote host to be reachable at all. If distcc silently drops them after the first connection setup, the resulting failure is confusing: the environment variable still looks correct to the user, but later connection attempts behave differently inside the process.

Keeping the original environment value intact makes repeated remote compiles consistent and keeps transport configuration under the user's control.

## Scope

This pull request is limited to preserving `DISTCC_SSH` across repeated Secure Shell connection setup and adding focused regression coverage. It does not include release, container, RPM packaging, or unrelated build-warning fixes.

## Scope boundaries

This Pull Request is limited to preserving configured Secure Shell options when distcc opens Secure Shell connections and to the tests that prove that behavior. It does not change non-Secure-Shell transport behavior, pump include-server behavior, compression behavior, release metadata, package files, or container files.

## Local Scope Evidence

The current branch only changes:

```text
Makefile.in
src/h_ssh.c
src/ssh.c
test/testdistcc.py
```

A scope check found no Docker, release workflow, RPM packaging, or release-package helper changes in this branch.

## Validation

Required before treating this as ready again:

```text
git diff --check
python3.13 -m py_compile test/testdistcc.py
./autogen.sh
PYTHON=/usr/bin/python3.13 ./configure --enable-Werror
make h_ssh
make TESTNAME=SecureShellCommandEnvironment_Case single-test
make check
local leak scan
```

## Changelog

I accidentally changed this pull request while testing release and packaging work. Those unrelated changes have been reversed, and the branch has been restored to the original intended scope: preserving `DISTCC_SSH` options across repeated Secure Shell connections only.