### PR TITLE
pump: fail closed on include server stalls

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -54,6 +54,8 @@ icondir = $(datarootdir)/pixmaps
 desktopdir = $(datarootdir)/applications
 
 include_server_builddir = $(builddir)/_include_server
+INCLUDE_SERVER_BUILD_REQUIRED = no
+INCLUDE_SERVER_CHECKS_STRICT = yes
 
 # These must be done from here, not from autoconf, because they can
 # contain variable expansions written in Make syntax.  Ew.
@@ -563,10 +565,17 @@ distccmon-gnome@EXEEXT@: $(mon_obj) $(gnome_obj)
 
 # The include-server is a python app, so we use Python's build system.  We pass
 # the distcc version, the source location, the CPP flags (for location of the
-# includes), and the build location.
+# includes), and the build location.  Keep a configurable strict mode because
+# some packaging paths intentionally tolerate builds without include-server,
+# while maintainer checks must fail if no include-server was actually built.
 include-server:
-	if test -z "$(PYTHON)"; then	\
-	  echo "Not building $@: No suitable python found"; \
+	if test -z "$(PYTHON)" || test "$(PYTHON)" = ":"; then	\
+	  if test "$(INCLUDE_SERVER_BUILD_REQUIRED)" = "yes"; then \
+	    echo "Cannot build $@: No suitable python found" 1>&2; \
+	    exit 1; \
+	  else \
+	    echo "Not building $@: No suitable python found"; \
+	  fi; \
 	else						\
 	  mkdir -p "$(include_server_builddir)" &&      \
 	  DISTCC_VERSION="$(VERSION)"			\
@@ -715,31 +724,42 @@ distcc-maintainer-check: check_programs
 	 $(MAKE) PATH="`pwd`:$(RESTRICTED_PATH)" \
 	   TESTDISTCC_OPTS="$(TESTDISTCC_OPTS)" maintainer-check-no-set-path
 
-# If the include server extension module was built, then run the tests include
-# server.  TODO(klarlund): the outermost if assumes that the include-server
-# target may be satisfied w/o actually building an include server (or rather the
-# C extension); this logic needs to be verified or amended.
+# If the include server extension module was built, then run the include server
+# tests.  Strict mode fails when the extension build directory is missing because
+# a successful skip can hide that no include server tests actually ran.  The
+# executed-test counter protects against an accidentally empty test list.
 # TODO(csilvers): keep track of failures instead of exiting on the first one.
+include-server-maintainer-check: INCLUDE_SERVER_BUILD_REQUIRED = $(INCLUDE_SERVER_CHECKS_STRICT)
 include-server-maintainer-check: include-server
 	@if ! test -d "$(include_server_builddir)"; then \
-	  echo "Skipped include-server check"; \
+	  if test "$(INCLUDE_SERVER_CHECKS_STRICT)" = "no"; then \
+	    echo "Skipped include-server check"; \
+	  else \
+	    echo "Missing include-server build directory: $(include_server_builddir)" 1>&2; \
+	    echo "Set INCLUDE_SERVER_CHECKS_STRICT=no to allow this check to skip." 1>&2; \
+	    exit 1; \
+	  fi; \
 	else \
 	  CURDIR=`pwd`; \
 	  include_server_loc=`"$(srcdir)/find_c_extension.sh" "$(builddir)"`; \
 	  test $$? = 0 || (echo 'Could not locate extension.' 1>&2 && exit 1); \
 	  cd "$(srcdir)/include_server"; \
+	  tests_run=0; \
 	  for p in $(check_include_server_PY); do \
 	    p_base=`basename "$$p"`; \
 	    echo "Running:" \
-              "PYTHONPATH=$$CURDIR/$$include_server_loc:$$PYTHONPATH $(PYTHON) $$p_base"; \
+	              "PYTHONPATH=$$CURDIR/$$include_server_loc:$$PYTHONPATH $(PYTHON) $$p_base"; \
+	    tests_run=$$((tests_run + 1)); \
 	    if PYTHONPATH="$$CURDIR/$$include_server_loc:$$PYTHONPATH" $(PYTHON) "$$p_base" \
 		 > "$$CURDIR/$(tempdir)/$$p_base.out" 2>&1; then \
 	      echo "PASS"; \
 	      rm "$$CURDIR/$(tempdir)/$$p_base.out"; \
             else \
-              echo "FAIL"; cat "$$CURDIR/$(tempdir)/$$p_base.out"; exit 1; \
+	              echo "FAIL"; cat "$$CURDIR/$(tempdir)/$$p_base.out"; exit 1; \
 	    fi; \
 	  done; \
+	  test "$$tests_run" -gt 0 || \
+	    (echo "No include-server tests were run." 1>&2 && exit 1); \
 	fi
 
 # Do distcc-maintainer-check in pump-mode, if possible.

--- a/find_c_extension.sh
+++ b/find_c_extension.sh
@@ -18,13 +18,25 @@ builddir="$1"
 # unpredictable 'ls' behavior when a glob has no matches.
 # (Side note: there is intense internal debate about whether the
 # '[sd][ol]' hack is "so ugly I can't stand it" or "kinda cute".)
-so_files=`ls $builddir/_include_server/lib.*/include_server/\
-distcc_pump_c_extensions*.[sd][ol]*`
-if [ -z "$so_files" ]; then
+so_count=0
+so_files=
+for file in "$builddir"/_include_server/lib.*/include_server/\
+distcc_pump_c_extensions*.[sd][ol]*; do
+  if [ -f "$file" ]; then
+    so_count=$((so_count + 1))
+    if [ -z "$so_files" ]; then
+      so_files=$file
+    else
+      so_files=$(printf '%s\n%s' "$so_files" "$file")
+    fi
+  fi
+done
+
+if [ "$so_count" -eq 0 ]; then
   echo \
     '__________Could not find shared libraries for distcc-pump' 1>&2
   exit 1
-elif [ `echo "$so_files" | wc -l` -ge 2 ]; then
+elif [ "$so_count" -ge 2 ]; then
   echo \
     '__________Shared libraries for multiple architectures discovered.' \
     1>&2

--- a/include_server/basics.py
+++ b/include_server/basics.py
@@ -29,6 +29,7 @@ import signal
 import shutil
 import sys
 import tempfile
+import time
 
 
 # MANAGEMENT OF TEMPORARY LOCATIONS FOR GENERATIONS OF COMPRESSED FILES
@@ -181,6 +182,7 @@ MAX_EMAILS_TO_SEND = 3
 # an amount of time roughly equal to this quota is wasted before CPP is invoked
 # instead.
 USER_TIME_QUOTA = 3.8  # seconds
+REQUEST_WALL_TIME_QUOTA = 30  # seconds
 
 # How often the following question is answered: has too much user time been
 # spent in the include handler servicing the current request?
@@ -353,10 +355,11 @@ class NotCoveredTimeOutError(NotCoveredError):
 
 
 class IncludeAnalyzerTimer(object):
-  """Start a timer limiting CPU time for servicing a single request.
+  """Start a timer limiting wall and CPU time for a single request.
 
-  We use user time so that a network hiccup will not entail a cache reset if,
-  say, we are using NFS.
+  Wall time protects the single-threaded include server from a client or request
+  that stops making progress.  User time preserves the existing cache reset
+  behavior for expensive include analysis.
 
   An object of this class must be instantiated so that, no matter what, the
   Cancel method is eventually called. This reinstates the original timer (if
@@ -364,13 +367,19 @@ class IncludeAnalyzerTimer(object):
   """
 
   def __init__(self):
+    self.start_wall_time = time.monotonic()
     self.start_utime = resource.getrusage(resource.RUSAGE_SELF).ru_utime
     self.old = signal.signal(signal.SIGALRM, self._TimeIsUp)
     signal.alarm(USER_TIME_QUOTA_CHECK_INTERVAL_TIME)
 
   def _TimeIsUp(self, unused_sig_number, unused_frame):
-    """Check CPU time spent and raise exception or reschedule."""
-    if (resource.getrusage(resource.RUSAGE_SELF).ru_utime
+    """Check request time spent and raise exception or reschedule."""
+    if time.monotonic() > self.start_wall_time + REQUEST_WALL_TIME_QUOTA:
+      raise NotCoveredTimeOutError(('Bailing out because include server '
+                                    + 'spent more than %ds wall time '
+                                    + 'handling request') %
+                                   REQUEST_WALL_TIME_QUOTA)
+    elif (resource.getrusage(resource.RUSAGE_SELF).ru_utime
         > self.start_utime + USER_TIME_QUOTA):
       raise NotCoveredTimeOutError(('Bailing out because include server '
                                     + 'spent more than %3.1fs user time '

--- a/include_server/basics.py
+++ b/include_server/basics.py
@@ -31,6 +31,8 @@ import sys
 import tempfile
 import time
 
+_Now = getattr(time, 'monotonic', time.time)
+
 
 # MANAGEMENT OF TEMPORARY LOCATIONS FOR GENERATIONS OF COMPRESSED FILES
 
@@ -367,14 +369,14 @@ class IncludeAnalyzerTimer(object):
   """
 
   def __init__(self):
-    self.start_wall_time = time.monotonic()
+    self.start_wall_time = _Now()
     self.start_utime = resource.getrusage(resource.RUSAGE_SELF).ru_utime
     self.old = signal.signal(signal.SIGALRM, self._TimeIsUp)
     signal.alarm(USER_TIME_QUOTA_CHECK_INTERVAL_TIME)
 
   def _TimeIsUp(self, unused_sig_number, unused_frame):
     """Check request time spent and raise exception or reschedule."""
-    if time.monotonic() > self.start_wall_time + REQUEST_WALL_TIME_QUOTA:
+    if _Now() > self.start_wall_time + REQUEST_WALL_TIME_QUOTA:
       raise NotCoveredTimeOutError(('Bailing out because include server '
                                     + 'spent more than %ds wall time '
                                     + 'handling request') %
@@ -388,6 +390,11 @@ class IncludeAnalyzerTimer(object):
     else:
       # Reschedule ourselves.
       signal.alarm(USER_TIME_QUOTA_CHECK_INTERVAL_TIME)
+
+  def RemainingWallTime(self):
+    """Return seconds left before the request wall-clock quota expires."""
+    remaining = self.start_wall_time + REQUEST_WALL_TIME_QUOTA - _Now()
+    return max(0.001, remaining)
 
   def Stop(self):
     signal.alarm(0)

--- a/include_server/basics_test.py
+++ b/include_server/basics_test.py
@@ -115,4 +115,14 @@ class BasicsTest(unittest.TestCase):
     finally:
       os.rmdir(os.environ['DISTCC_CLIENT_TMP'])
 
+  def test_IncludeAnalyzerTimer_WallTimeQuota(self):
+    """The request timer must fail requests that exceed wall time."""
+    timer = basics.IncludeAnalyzerTimer()
+    try:
+      timer.start_wall_time -= basics.REQUEST_WALL_TIME_QUOTA + 1
+      self.assertRaises(basics.NotCoveredTimeOutError,
+                        timer._TimeIsUp, None, None)
+    finally:
+      timer.Cancel()
+
 unittest.main()

--- a/include_server/c_extensions/distcc_pump_c_extensions_module.c
+++ b/include_server/c_extensions/distcc_pump_c_extensions_module.c
@@ -23,6 +23,12 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 static const char *version = ".01";
 
@@ -106,6 +112,179 @@ RCwd(PyObject *dummy, PyObject *args) {
 }
 
 
+static void
+AddSecondsToTimeval(struct timeval *tv, double seconds) {
+  long whole_seconds = (long)seconds;
+  long microseconds = (long)((seconds - whole_seconds) * 1000000.0);
+
+  tv->tv_sec += whole_seconds;
+  tv->tv_usec += microseconds;
+  if (tv->tv_usec >= 1000000) {
+    tv->tv_sec += 1;
+    tv->tv_usec -= 1000000;
+  }
+}
+
+
+static int
+TimevalExpired(struct timeval *remaining,
+               const struct timeval *deadline,
+               const struct timeval *now) {
+  remaining->tv_sec = deadline->tv_sec - now->tv_sec;
+  remaining->tv_usec = deadline->tv_usec - now->tv_usec;
+  if (remaining->tv_usec < 0) {
+    remaining->tv_sec -= 1;
+    remaining->tv_usec += 1000000;
+  }
+  return remaining->tv_sec < 0 ||
+         (remaining->tv_sec == 0 && remaining->tv_usec <= 0);
+}
+
+
+static int
+ReadWithDeadline(int fd, void *buf, size_t len,
+                 const struct timeval *deadline) {
+  while (len > 0) {
+    fd_set read_fds;
+    struct timeval now;
+    struct timeval remaining;
+    int select_result;
+    ssize_t read_result;
+
+    if (gettimeofday(&now, NULL) != 0) {
+      PyErr_SetFromErrno(distcc_pump_c_extensionsError);
+      return 1;
+    }
+    if (TimevalExpired(&remaining, deadline, &now)) {
+      PyErr_SetString(distcc_pump_c_extensionsError,
+                      "Timed out reading include server request.");
+      return 1;
+    }
+
+    FD_ZERO(&read_fds);
+    FD_SET(fd, &read_fds);
+    select_result = select(fd + 1, &read_fds, NULL, NULL, &remaining);
+    if (select_result == -1 && errno == EINTR)
+      continue;
+    if (select_result == -1) {
+      PyErr_SetFromErrno(distcc_pump_c_extensionsError);
+      return 1;
+    }
+    if (select_result == 0) {
+      PyErr_SetString(distcc_pump_c_extensionsError,
+                      "Timed out reading include server request.");
+      return 1;
+    }
+
+    read_result = read(fd, buf, len);
+    if (read_result == -1 && (errno == EINTR || errno == EAGAIN))
+      continue;
+    if (read_result == -1) {
+      PyErr_SetFromErrno(distcc_pump_c_extensionsError);
+      return 1;
+    }
+    if (read_result == 0) {
+      PyErr_SetString(distcc_pump_c_extensionsError,
+                      "Unexpected EOF reading include server request.");
+      return 1;
+    }
+    buf = &((char *)buf)[read_result];
+    len -= (size_t)read_result;
+  }
+  return 0;
+}
+
+
+static int
+ReadTokenIntWithDeadline(int fd, const char *expected, unsigned *value,
+                         const struct timeval *deadline) {
+  char buf[13];
+  char *endptr;
+
+  if (strlen(expected) != 4) {
+    PyErr_SetString(distcc_pump_c_extensionsError,
+                    "Expected token name must have length 4.");
+    return 1;
+  }
+  if (ReadWithDeadline(fd, buf, 12, deadline))
+    return 1;
+  if (memcmp(buf, expected, 4)) {
+    PyErr_Format(distcc_pump_c_extensionsError,
+                 "Protocol derailment: expected token \"%s\".", expected);
+    return 1;
+  }
+  buf[12] = '\0';
+  *value = (unsigned)strtoul(&buf[4], &endptr, 16);
+  if (endptr != &buf[12]) {
+    PyErr_Format(distcc_pump_c_extensionsError,
+                 "Failed to parse parameter of token \"%s\".", expected);
+    return 1;
+  }
+  return 0;
+}
+
+
+static int
+ReadTokenStringWithDeadline(int fd, const char *expected, char **value,
+                            const struct timeval *deadline) {
+  unsigned length;
+  char *buffer;
+
+  if (ReadTokenIntWithDeadline(fd, expected, &length, deadline))
+    return 1;
+  buffer = (char *)malloc((size_t)length + 1);
+  if (buffer == NULL) {
+    PyErr_NoMemory();
+    return 1;
+  }
+  if (ReadWithDeadline(fd, buffer, (size_t)length, deadline)) {
+    free(buffer);
+    return 1;
+  }
+  buffer[length] = '\0';
+  *value = buffer;
+  return 0;
+}
+
+
+static char RCwdTimeout_doc__[] =
+"RCwdTimeout(ifd, timeout_seconds):\n"
+"   Read value of current directory with a wall-clock deadline.\n"
+"\n"
+"   Arguments:\n"
+"     ifd: an integer file descriptor\n"
+"     timeout_seconds: maximum seconds spent reading this request\n"
+"   Raises:\n"
+"     distcc_pump_c_extensions.Error\n"
+;
+static PyObject *
+RCwdTimeout(PyObject *dummy, PyObject *args) {
+  int ifd;
+  double timeout_seconds;
+  struct timeval deadline;
+  char *value_str = NULL;
+  PyObject *result;
+  UNUSED(dummy);
+  if (!PyArg_ParseTuple(args, "id", &ifd, &timeout_seconds))
+    return NULL;
+  if (timeout_seconds <= 0) {
+    PyErr_SetString(distcc_pump_c_extensionsError,
+                    "Request read timeout must be positive.");
+    return NULL;
+  }
+  if (gettimeofday(&deadline, NULL) != 0) {
+    PyErr_SetFromErrno(distcc_pump_c_extensionsError);
+    return NULL;
+  }
+  AddSecondsToTimeval(&deadline, timeout_seconds);
+  if (ReadTokenStringWithDeadline(ifd, "CDIR", &value_str, &deadline))
+    return NULL;
+  result = PyUnicode_FromString(value_str);
+  free(value_str);
+  return result;
+}
+
+
 static char RTokenString_doc__[] =
 "RTokenString(ifd, expect_token):\n"
 "   Read value of expected token.\n"
@@ -178,6 +357,67 @@ RArgv(PyObject *dummy, PyObject *args) {
     free(argv[i]);
   free(argv);
   return NULL;
+}
+
+
+static char RArgvTimeout_doc__[] =
+"RArgvTimeout(ifd, timeout_seconds):\n"
+"   Read argv values with a wall-clock deadline.\n"
+"\n"
+"   Arguments:\n"
+"     ifd: an integer file descriptor\n"
+"     timeout_seconds: maximum seconds spent reading this request\n"
+"   Raises:\n"
+"     distcc_pump_c_extensions.Error\n"
+;
+static PyObject *
+RArgvTimeout(PyObject *dummy, PyObject *args) {
+  int ifd;
+  double timeout_seconds;
+  struct timeval deadline;
+  unsigned argc;
+  unsigned i;
+  PyObject *list_object = NULL;
+  PyObject *string_object = NULL;
+  UNUSED(dummy);
+
+  if (!PyArg_ParseTuple(args, "id", &ifd, &timeout_seconds))
+    return NULL;
+  if (timeout_seconds <= 0) {
+    PyErr_SetString(distcc_pump_c_extensionsError,
+                    "Request read timeout must be positive.");
+    return NULL;
+  }
+  if (gettimeofday(&deadline, NULL) != 0) {
+    PyErr_SetFromErrno(distcc_pump_c_extensionsError);
+    return NULL;
+  }
+  AddSecondsToTimeval(&deadline, timeout_seconds);
+  if (ReadTokenIntWithDeadline(ifd, "ARGC", &argc, &deadline))
+    return NULL;
+  list_object = PyList_New(0);
+  if (list_object == NULL)
+    return NULL;
+  for (i = 0; i < argc; i++) {
+    char *arg = NULL;
+    if (ReadTokenStringWithDeadline(ifd, "ARGV", &arg, &deadline)) {
+      Py_DECREF(list_object);
+      return NULL;
+    }
+    string_object = PyUnicode_FromString(arg);
+    free(arg);
+    if (string_object == NULL) {
+      Py_DECREF(list_object);
+      return NULL;
+    }
+    if (PyList_Append(list_object, string_object) < 0) {
+      Py_DECREF(string_object);
+      Py_DECREF(list_object);
+      return NULL;
+    }
+    Py_DECREF(string_object);
+  }
+  return list_object;
 }
 
 
@@ -394,6 +634,9 @@ static PyMethodDef module_methods[] = {
    RTokenString_doc__},
   {"RCwd",        (PyCFunction)RCwd,    METH_VARARGS, RCwd_doc__},
   {"RArgv",       (PyCFunction)RArgv,   METH_VARARGS, RArgv_doc__},
+  {"RCwdTimeout", (PyCFunction)RCwdTimeout, METH_VARARGS, RCwdTimeout_doc__},
+  {"RArgvTimeout",(PyCFunction)RArgvTimeout, METH_VARARGS,
+   RArgvTimeout_doc__},
   {"XArgv",       (PyCFunction)XArgv,   METH_VARARGS, XArgv_doc__},
   {"CompressLzo1xAlloc", (PyCFunction)CompressLzo1xAlloc, METH_VARARGS,
    CompressLzo1xAlloc_doc__},

--- a/include_server/c_extensions_test.py
+++ b/include_server/c_extensions_test.py
@@ -29,6 +29,7 @@ __author__ = 'opensource@google.com'
 
 import os.path
 import random
+import socket
 import sys
 import time
 
@@ -95,6 +96,22 @@ def RunTest(random_filename):
   if args != darth_vader_barney:
     raise distcc_pump_c_extensions.error('internal error 4')
   fd.close()
+
+  # Deadline-bound request reads must fail quickly when a client connects but
+  # does not send the expected distcc-pump RPC data.
+  reader, writer = socket.socketpair()
+  try:
+    start = time.time()
+    try:
+      distcc_pump_c_extensions.RCwdTimeout(reader.fileno(), 0.1)
+      raise distcc_pump_c_extensions.Error('timeout was not enforced')
+    except distcc_pump_c_extensions.Error:
+      pass
+    if time.time() - start > 2.0:
+      raise distcc_pump_c_extensions.Error('timeout took too long')
+  finally:
+    reader.close()
+    writer.close()
 
   # Libc functions --- also print out how fast they are compared to
   # Python built-ins.

--- a/include_server/include_server.py
+++ b/include_server/include_server.py
@@ -36,6 +36,7 @@ import signal
 import socketserver
 import sys
 import tempfile
+import time
 import traceback
 
 # Include server imports
@@ -366,8 +367,15 @@ def DistccIncludeHandlerGenerator(include_analyzer):
 
       try:
         try:
-          currdir = distcc_pump_c_extensions.RCwd(self.rfile.fileno())
-          cmd = distcc_pump_c_extensions.RArgv(self.rfile.fileno())
+          try:
+            currdir = distcc_pump_c_extensions.RCwdTimeout(
+                self.rfile.fileno(), include_analyzer.timer.RemainingWallTime())
+            cmd = distcc_pump_c_extensions.RArgvTimeout(
+                self.rfile.fileno(), include_analyzer.timer.RemainingWallTime())
+          except distcc_pump_c_extensions.Error as inst:
+            if 'Timed out reading include server request.' in str(inst):
+              raise basics.NotCoveredTimeOutError(str(inst))
+            raise
           # We do timeout the include_analyzer using the crude mechanism of
           # SIGALRM. This signal is problematic if raised while Python is doing
           # I/O in the C extensions and during use of the subprocess
@@ -589,11 +597,37 @@ class _IncludeServerPortReady(object):
     """
     (self.read_fd, self.write_fd) = os.pipe()
 
-  def Acquire(self):
+  def _StopChild(self, child_pid):
+    """Stop a child that outlived the startup readiness deadline."""
+    if child_pid is None:
+      return
+    try:
+      os.kill(child_pid, signal.SIGTERM)
+    except OSError:
+      return
+    for unused_i in range(100):
+      try:
+        done_pid, unused_status = os.waitpid(child_pid, os.WNOHANG)
+      except OSError:
+        return
+      if done_pid == child_pid:
+        return
+      time.sleep(0.01)
+    try:
+      os.kill(child_pid, signal.SIGKILL)
+    except OSError:
+      return
+    try:
+      os.waitpid(child_pid, 0)
+    except OSError:
+      pass
+
+  def Acquire(self, child_pid=None):
     """Acquire the semaphore after fork without waiting forever."""
     readable, unused_writable, unused_error = select.select(
         [self.read_fd], [], [], self.TIMEOUT_SECONDS)
     if not readable:
+      self._StopChild(child_pid)
       sys.exit("Include server: timed out waiting for startup.")
     status = os.read(self.read_fd, 1)
     if status == self.FAILED:
@@ -679,7 +713,7 @@ def Main():
       print(pid, file=pid_file_fd)
       pid_file_fd.close()
     # Just run to completion now -- after making sure that child is ready.
-    include_server_port_ready.Acquire()
+    include_server_port_ready.Acquire(pid)
     # concerned.
   else:
     # In child.
@@ -691,10 +725,11 @@ def Main():
     try:
       (include_analyzer, server) = _SetUp(include_server_port)
     except:
-      include_server_port_ready.Fail()
       print("Include server: exception occurred during startup.",
               file=sys.stderr)
       _PrintStackTrace(sys.stderr)
+      sys.stderr.flush()
+      include_server_port_ready.Fail()
       _CleanOut(include_analyzer, include_server_port)
       sys.exit(1)
     include_server_port_ready.Release()

--- a/include_server/include_server.py
+++ b/include_server/include_server.py
@@ -30,6 +30,7 @@ import getopt
 import glob
 import os
 import re
+import select
 import shutil
 import signal
 import socketserver
@@ -361,11 +362,12 @@ def DistccIncludeHandlerGenerator(include_analyzer):
        - Transmit the file and link names on the socket using the RPC protocol.
       """
       statistics.StartTiming()
-      currdir = distcc_pump_c_extensions.RCwd(self.rfile.fileno())
-      cmd = distcc_pump_c_extensions.RArgv(self.rfile.fileno())
+      include_analyzer.timer = basics.IncludeAnalyzerTimer()
 
       try:
         try:
+          currdir = distcc_pump_c_extensions.RCwd(self.rfile.fileno())
+          cmd = distcc_pump_c_extensions.RArgv(self.rfile.fileno())
           # We do timeout the include_analyzer using the crude mechanism of
           # SIGALRM. This signal is problematic if raised while Python is doing
           # I/O in the C extensions and during use of the subprocess
@@ -385,7 +387,6 @@ def DistccIncludeHandlerGenerator(include_analyzer):
           # link operations instead of actually executing them on the spot. The
           # accumulated operations can be executed after DoCompilationCommand
           # when the timer has been cancelled.
-          include_analyzer.timer = basics.IncludeAnalyzerTimer()
           files_and_links = (
               include_analyzer.
                   DoCompilationCommand(cmd, currdir,
@@ -577,6 +578,10 @@ class _IncludeServerPortReady(object):
 
    The implementation uses an unnamed pipe."""
 
+  READY = b'\n'
+  FAILED = b'!'
+  TIMEOUT_SECONDS = 30
+
   def __init__(self):
     """Constructor.
 
@@ -585,14 +590,28 @@ class _IncludeServerPortReady(object):
     (self.read_fd, self.write_fd) = os.pipe()
 
   def Acquire(self):
-    """Acquire the semaphore after fork;  blocks until a call of Release."""
-    if os.read(self.read_fd, 1) != b'\n':
+    """Acquire the semaphore after fork without waiting forever."""
+    readable, unused_writable, unused_error = select.select(
+        [self.read_fd], [], [], self.TIMEOUT_SECONDS)
+    if not readable:
+      sys.exit("Include server: timed out waiting for startup.")
+    status = os.read(self.read_fd, 1)
+    if status == self.FAILED:
+      sys.exit(1)
+    if status != self.READY:
       sys.exit("Include server: _IncludeServerPortReady.Acquire failed.")
 
   def Release(self):
     """Release the semaphore after fork."""
-    if os.write(self.write_fd, b'\n') != 1:
+    if os.write(self.write_fd, self.READY) != 1:
       sys.exit("Include server: _IncludeServerPortReady.Release failed.")
+
+  def Fail(self):
+    """Tell the parent that startup failed before the server became ready."""
+    try:
+      os.write(self.write_fd, self.FAILED)
+    except OSError:
+      pass
 
 
 def _SetUp(include_server_port):
@@ -668,7 +687,16 @@ def Main():
     # We call _Setup only now, because the process id, used in naming the client
     # root, must be that of this process, not that of the parent process. See
     # _CleanOutOthers for the importance of the process id.
-    (include_analyzer, server) = _SetUp(include_server_port)
+    include_analyzer = None
+    try:
+      (include_analyzer, server) = _SetUp(include_server_port)
+    except:
+      include_server_port_ready.Fail()
+      print("Include server: exception occurred during startup.",
+              file=sys.stderr)
+      _PrintStackTrace(sys.stderr)
+      _CleanOut(include_analyzer, include_server_port)
+      sys.exit(1)
     include_server_port_ready.Release()
     try:
       try:

--- a/include_server/include_server_test.py
+++ b/include_server/include_server_test.py
@@ -26,7 +26,9 @@ ultimately the notion of an AssertionError.
 __author__ = "Nils Klarlund"
 
 import os
+import subprocess
 import sys
+import tempfile
 import traceback
 import unittest
 
@@ -178,10 +180,57 @@ class IncludeServerTest(unittest.TestCase):
     except NotCoveredError:
       pass
 
+    # Exercise 4: the request timer must already be active while the handler
+    # reads the request from the client.
+    timer_was_active = []
+
+    def TimedOutRCwd(unused_self):
+      timer_was_active.append(include_analyzer.timer is not None)
+      raise basics.NotCoveredTimeOutError('request read timed out')
+
+    def Expect4(txt, force, never):
+      self_test.assertTrue('request read timed out' in txt, txt)
+      self_test.assertEqual(never, False)
+
+    mock_email_sender.expect = Expect4
+    distcc_pump_c_extensions.RCwd = TimedOutRCwd
+    distcc_pump_c_extensions.RArgv = lambda self: [ "gcc", "parse.c" ]
+    try:
+      include_handler.handle()
+    except basics.NotCoveredTimeOutError:
+      pass
+    self.assertEqual(timer_was_active, [True])
+
     distcc_pump_c_extensions.RWcd = old_RWcd
     distcc_pump_c_extensions.RArgv = old_RArgv
     distcc_pump_c_extensions.XArgv = old_XArgv
     include_server.socketserver.StreamRequestHandler = (
       old_StreamRequestHandler)
+
+  def test_Main_reports_setup_failure_without_hanging(self):
+    """A pre-ready startup failure must not leave the parent blocked."""
+    missing_root = tempfile.mkdtemp()
+    missing_parent = os.path.join(missing_root, 'missing-parent')
+    socket_path = os.path.join(missing_parent, 'socket')
+    pid_file = tempfile.NamedTemporaryFile(delete=False)
+    pid_file.close()
+    try:
+      result = subprocess.run(
+          [sys.executable, 'include_server.py',
+           '--port', socket_path, '--pid_file', pid_file.name, '-d1'],
+          stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+          timeout=5)
+      self.assertNotEqual(result.returncode, 0)
+      self.assertIn('Include server: exception occurred during startup.',
+                    result.stderr)
+    finally:
+      try:
+        os.unlink(pid_file.name)
+      except OSError:
+        pass
+      try:
+        os.rmdir(missing_root)
+      except OSError:
+        pass
 
 unittest.main()

--- a/include_server/include_server_test.py
+++ b/include_server/include_server_test.py
@@ -64,10 +64,14 @@ class IncludeServerTest(unittest.TestCase):
   def test_IncludeHandler_handle(self):
     self_test = self
     client_root_keeper = basics.ClientRootKeeper()
-    old_RWcd = distcc_pump_c_extensions.RCwd
+    old_RCwd = distcc_pump_c_extensions.RCwd
     distcc_pump_c_extensions.RCwd = None # to be set below
+    old_RCwdTimeout = distcc_pump_c_extensions.RCwdTimeout
+    distcc_pump_c_extensions.RCwdTimeout = None # to be set below
     old_RArgv = distcc_pump_c_extensions.RArgv
     distcc_pump_c_extensions.RArgv = None # to be set below
+    old_RArgvTimeout = distcc_pump_c_extensions.RArgvTimeout
+    distcc_pump_c_extensions.RArgvTimeout = None # to be set below
     old_XArgv = distcc_pump_c_extensions.XArgv
     distcc_pump_c_extensions.XArgv = lambda _, __: None
     old_StreamRequestHandler = (
@@ -109,8 +113,10 @@ class IncludeServerTest(unittest.TestCase):
 
     # Exercise 1: non-existent translation unit.
 
-    distcc_pump_c_extensions.RArgv = lambda self: [ "gcc", "parse.c" ]
-    distcc_pump_c_extensions.RCwd = lambda self: os.getcwd()
+    distcc_pump_c_extensions.RArgvTimeout = (
+        lambda unused_self, unused_timeout: [ "gcc", "parse.c" ])
+    distcc_pump_c_extensions.RCwdTimeout = (
+        lambda unused_self, unused_timeout: os.getcwd())
 
     def Expect1(txt, force, never):
       self_test.assertTrue(
@@ -130,8 +136,10 @@ class IncludeServerTest(unittest.TestCase):
     # Exercise 2: provoke assertion error in cache_basics by providing an
     # entirely false value of current directory as provided in RCwd.
 
-    distcc_pump_c_extensions.RArgv = lambda self: [ "gcc", "parse.c" ]
-    distcc_pump_c_extensions.RCwd = lambda self: "/"
+    distcc_pump_c_extensions.RArgvTimeout = (
+        lambda unused_self, unused_timeout: [ "gcc", "parse.c" ])
+    distcc_pump_c_extensions.RCwdTimeout = (
+        lambda unused_self, unused_timeout: "/")
     # The cwd will be changed because of false value.
     oldcwd = os.getcwd()
 
@@ -163,9 +171,11 @@ class IncludeServerTest(unittest.TestCase):
 
     # Exercise 3: provoke a NotCoveredError due to an absolute #include.
 
-    distcc_pump_c_extensions.RArgv = lambda self: [ "gcc",
-      "test_data/contains_abs_include.c" ]
-    distcc_pump_c_extensions.RCwd = lambda self: os.getcwd()
+    distcc_pump_c_extensions.RArgvTimeout = (
+        lambda unused_self, unused_timeout:
+            [ "gcc", "test_data/contains_abs_include.c" ])
+    distcc_pump_c_extensions.RCwdTimeout = (
+        lambda unused_self, unused_timeout: os.getcwd())
 
     def Expect3(txt, force, never):
       self_test.assertTrue(
@@ -184,25 +194,30 @@ class IncludeServerTest(unittest.TestCase):
     # reads the request from the client.
     timer_was_active = []
 
-    def TimedOutRCwd(unused_self):
+    def TimedOutRCwd(unused_self, unused_timeout):
       timer_was_active.append(include_analyzer.timer is not None)
-      raise basics.NotCoveredTimeOutError('request read timed out')
+      raise distcc_pump_c_extensions.Error(
+          'Timed out reading include server request.')
 
     def Expect4(txt, force, never):
-      self_test.assertTrue('request read timed out' in txt, txt)
+      self_test.assertTrue('Timed out reading include server request.' in txt,
+                           txt)
       self_test.assertEqual(never, False)
 
     mock_email_sender.expect = Expect4
-    distcc_pump_c_extensions.RCwd = TimedOutRCwd
-    distcc_pump_c_extensions.RArgv = lambda self: [ "gcc", "parse.c" ]
+    distcc_pump_c_extensions.RCwdTimeout = TimedOutRCwd
+    distcc_pump_c_extensions.RArgvTimeout = (
+        lambda unused_self, unused_timeout: [ "gcc", "parse.c" ])
     try:
       include_handler.handle()
     except basics.NotCoveredTimeOutError:
       pass
     self.assertEqual(timer_was_active, [True])
 
-    distcc_pump_c_extensions.RWcd = old_RWcd
+    distcc_pump_c_extensions.RCwd = old_RCwd
+    distcc_pump_c_extensions.RCwdTimeout = old_RCwdTimeout
     distcc_pump_c_extensions.RArgv = old_RArgv
+    distcc_pump_c_extensions.RArgvTimeout = old_RArgvTimeout
     distcc_pump_c_extensions.XArgv = old_XArgv
     include_server.socketserver.StreamRequestHandler = (
       old_StreamRequestHandler)
@@ -232,5 +247,28 @@ class IncludeServerTest(unittest.TestCase):
         os.rmdir(missing_root)
       except OSError:
         pass
+
+  def test_IncludeServerPortReady_timeout_stops_child(self):
+    """A startup timeout must not leave the forked child running."""
+    port_ready = include_server._IncludeServerPortReady()
+    old_timeout = port_ready.TIMEOUT_SECONDS
+    port_ready.TIMEOUT_SECONDS = 0.1
+    pid = os.fork()
+    if pid == 0:
+      try:
+        sys.exit(0 if os.read(port_ready.read_fd, 1) else 0)
+      except KeyboardInterrupt:
+        sys.exit(1)
+    try:
+      self.assertRaises(SystemExit, port_ready.Acquire, pid)
+    finally:
+      port_ready.TIMEOUT_SECONDS = old_timeout
+      try:
+        os.kill(pid, 0)
+      except OSError:
+        pass
+      else:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
 
 unittest.main()

--- a/include_server/run.py
+++ b/include_server/run.py
@@ -104,3 +104,4 @@ except OSError:
   print("Could not run: '%s' with arguments: %s" %
     (os.path.join(directory, sys.argv[1]),
      sys.argv[1:]), file=sys.stderr)
+  sys.exit(1)

--- a/pump.in
+++ b/pump.in
@@ -247,6 +247,10 @@ StartIncludeServer() {
     # directory. Possibly there may be more than one such file; first identify
     # them all.
     so_dir=`"$distcc_srcdir/find_c_extension.sh" "$DISTCC_LOCATION"`
+    if [ $? -ne 0 ] || [ -z "$so_dir" ]; then
+      echo "__________Could not locate distcc-pump C-extension directory." 1>&2
+      return 1
+    fi
     pythonpath="$so_dir"
   fi
 
@@ -364,13 +368,43 @@ ShutDown() {
     if [ "$verbose" = 1 ]; then
       echo '__________Shutting down distcc-pump include server'
     fi
-    kill $include_server_pid
-    # Wait until it's really dead.  We need to do this because the
-    # include server may produce output after receiving SIGTERM.
-    # Note that while 'sleep 0.01' is relying on a feature of GNU sleep,
-    # that's OK; on systems that don't support it, it's effectively the
-    # same as 'sleep 0', i.e. we'll just busy-wait rather than sleeping.
-    while kill -0 $include_server_pid; do sleep 0.01; done >/dev/null 2>&1
+    if ! kill "$include_server_pid"; then
+      echo '__________Could not send SIGTERM to distcc-pump include server' 1>&2
+    else
+      # Allow a short grace period for clean exit, then force kill.
+      include_server_wait_count=0
+      include_server_wait_limit=200   # 200 * 0.01s ~= 2s
+      while ps -p "$include_server_pid" > /dev/null; do
+        if [ "$include_server_wait_count" -ge "$include_server_wait_limit" ]; then
+          echo '__________Timed out waiting for distcc-pump include server' \
+               'to stop after SIGTERM' 1>&2
+          break
+        fi
+        include_server_wait_count=`expr "$include_server_wait_count" + 1`
+        sleep 0.01
+      done
+    fi
+
+    if ps -p "$include_server_pid" > /dev/null; then
+      echo '__________Sending SIGKILL to unresponsive distcc-pump' \
+           'include server' 1>&2
+      if kill -9 "$include_server_pid"; then
+        include_server_wait_count=0
+        include_server_wait_limit=100   # 100 * 0.01s ~= 1s
+        while ps -p "$include_server_pid" > /dev/null; do
+          if [ "$include_server_wait_count" -ge "$include_server_wait_limit" ]; then
+            echo '__________Error: distcc-pump include server did not exit after SIGKILL' \
+                 1>&2
+            break
+          fi
+          include_server_wait_count=`expr "$include_server_wait_count" + 1`
+          sleep 0.01
+        done
+      else
+        echo '__________Error: could not send SIGKILL to distcc-pump include server' \
+             1>&2
+      fi
+    fi
   fi
 
   if [ -f "$include_server_stdout" ]; then

--- a/pump.in
+++ b/pump.in
@@ -217,6 +217,15 @@ PrintIncludeServerStatusMessage() {
   fi
 }
 
+PrintIncludeServerOutput() {
+  if [ -f "$include_server_stdout" ]; then
+    cat "$include_server_stdout"
+  fi
+  if [ -f "$include_server_stderr" ]; then
+    cat "$include_server_stderr" >&2
+  fi
+}
+
 Announce() {
   if [ "$verbose" = 1 ]; then
     echo "__________Using distcc-pump from $DISTCC_LOCATION"
@@ -322,6 +331,7 @@ StartIncludeServer() {
   if $TEST ! -S "$socket"; then
     echo "__________Expected a socket at '$socket'" 1>&2
     PrintIncludeServerStatusMessage 1
+    PrintIncludeServerOutput
     return 1
   fi
 
@@ -338,6 +348,7 @@ StartIncludeServer() {
     # socket is not working.
     include_server_pid=''
     PrintIncludeServerStatusMessage 1
+    PrintIncludeServerOutput
     return 1
   fi
 }
@@ -407,12 +418,7 @@ ShutDown() {
     fi
   fi
 
-  if [ -f "$include_server_stdout" ]; then
-    cat "$include_server_stdout"
-  fi
-  if [ -f "$include_server_stderr" ]; then
-    cat "$include_server_stderr" >&2
-  fi
+  PrintIncludeServerOutput
 
   if [ -n "$socket_dir" ];  then
     rm -rf "$socket_dir"


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Fixes #584.

## Summary

This Pull Request makes several pump include-server failure paths fail closed instead of hanging, skipping silently, or reporting success without proving that the include-server checks actually ran.

The common theme is bounded failure behavior. If the include server cannot start correctly, cannot finish a request in time, cannot discover the required C extension, or cannot complete its maintainer checks in strict mode, the command should return a clear failure instead of leaving users with a stalled pump session or a misleading green test result.

## What This Actually Changes

Pump include-server startup and request handling are made stricter and more bounded. A child-process startup failure before readiness is now reported back instead of letting the parent wait indefinitely. Include request processing now has a wall-clock deadline in addition to the existing CPU/user-time limit, so a request that stalls while reading input is still bounded.

The maintainer include-server check is also made stricter by default. A skipped include-server test is not treated as success in strict mode, because a skipped check does not prove that the include server works. If a non-strict skip is needed, it has to be selected deliberately instead of becoming an accidental green result.

## What this PR fixes

One failure mode is a startup stall. Expected behavior is:

```text
include-server child setup fails -> parent sees the failure -> pump exits non-zero
```

The unsafe behavior is:

```text
include-server child setup fails before readiness -> parent keeps waiting -> pump appears hung
```

A second failure mode is a request that blocks while reading data. The previous CPU-time based timeout can miss that kind of stall because a blocked read may consume little or no CPU time. The added wall-clock deadline covers the user-visible case: the request takes too long in real time and must fail closed.

A third failure mode is a misleading maintainer check. If the include-server test path skips all relevant tests, the check output can look successful even though it did not verify the include server. In strict mode, that is now treated as failure.

## What changed in code

`include_server/include_server.py` reports child setup failures during startup and starts request timing before reading request data. This is the main runtime change that prevents startup and request stalls from becoming unbounded waits.

`include_server/basics.py` and the include-server tests cover the new wall-clock timeout behavior. `include_server/include_server_test.py` covers the pre-ready startup failure path so the regression cannot quietly return.

`find_c_extension.sh`, `pump.in`, and `include_server/run.py` fail closed when extension discovery or process replacement fails. `pump.in` also bounds shutdown waiting after `SIGTERM` so cleanup does not wait forever.

## Why this matters for users

Pump users usually see these problems as a build that stops making progress, not as an obvious compiler error. That is especially hard to diagnose on remote or clustered builds, because the visible symptom can be only that pump never completes startup, shutdown, or one include request.

For maintainers, the strict test behavior matters because a skipped include-server check is not proof. It can hide the exact class of problem this Pull Request is trying to catch. Making that strict by default keeps a green result meaningful.

## Scope boundaries

This Pull Request is limited to pump include-server fail-closed behavior, timeout handling, extension discovery failure handling, and the tests that prove those paths. It does not add release metadata, package files, container files, RPM or Debian packaging changes, compression changes, or unrelated daemon behavior changes.

## Local Scope Evidence

Current branch scope is limited to these files:

```text
Makefile.in
find_c_extension.sh
include_server/basics.py
include_server/basics_test.py
include_server/c_extensions/distcc_pump_c_extensions_module.c
include_server/c_extensions_test.py
include_server/include_server.py
include_server/include_server_test.py
include_server/run.py
pump.in
```

No Dockerfile, release workflow, RPM spec, Debian packaging file, or container entrypoint file is part of this Pull Request.

## Validation

Local validation for this branch should include the include-server test suite paths touched by this Pull Request, the pump startup and shutdown paths, and the strict include-server maintainer-check behavior. A warning, skipped strict include-server check, startup failure, or timeout failure must be treated as a failed validation result.

## Changelog

I accidentally changed this Pull Request while testing release and packaging work. Those unrelated changes have been reversed, and the branch has been restored to the original intended scope: pump include-server fail-closed stall and timeout behavior only.