### PR TITLE
distccd: prune stale compile stats before accounting

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -300,6 +300,8 @@ h_scanargs_obj = src/h_scanargs.o $(common_obj)
 h_hosts_obj = src/h_hosts.o $(common_obj)
 h_argvtostr_obj = src/h_argvtostr.o $(common_obj)
 h_strip_obj = src/h_strip.o $(common_obj) src/strip.o
+h_stats_obj = src/h_stats.o src/h_stats_stats.o $(common_obj) src/srvnet.o \
+	      src/access.o
 h_parsemask_obj = src/h_parsemask.o $(common_obj) src/access.o
 h_sa2str_obj = src/h_sa2str.o $(common_obj) src/srvnet.o src/access.o
 h_ccvers_obj = src/h_ccvers.o $(common_obj)
@@ -324,7 +326,7 @@ SRC =	src/stats.c							\
 	src/h_argvtostr.c						\
 	src/h_exten.c src/h_hosts.c src/h_issource.c src/h_parsemask.c	\
 	src/h_sa2str.c src/h_scanargs.c src/h_strip.c			\
-	src/h_dotd.c src/h_compile.c src/h_getline.c			\
+	src/h_stats.c src/h_dotd.c src/h_compile.c src/h_getline.c	\
 	src/help.c src/history.c src/hosts.c src/hostfile.c		\
 	src/implicit.c src/io.c						\
 	src/loadfile.c src/lock.c 					\
@@ -418,6 +420,7 @@ check_PROGRAMS = \
 	h_parsemask@EXEEXT@ \
 	h_sa2str@EXEEXT@ \
 	h_scanargs@EXEEXT@ \
+	h_stats@EXEEXT@ \
 	h_strip@EXEEXT@ \
 	h_dotd@EXEEXT@ \
 	h_compile@EXEEXT@ \
@@ -525,6 +528,9 @@ h_parsemask@EXEEXT@: $(h_parsemask_obj)
 h_strip@EXEEXT@: $(h_strip_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_strip_obj) $(LIBS)
 
+h_stats@EXEEXT@: $(h_stats_obj)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_stats_obj) $(LIBS)
+
 h_ccvers@EXEEXT@: $(h_ccvers_obj)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(h_ccvers_obj) $(LIBS)
 
@@ -545,6 +551,11 @@ src/h_fix_debug_info.o: src/fix_debug_info.c
 	$(CC) -c -o $@ $(CPPFLAGS) $(CFLAGS) \
 		-DTEST \
 		$(srcdir)/src/fix_debug_info.c
+
+src/h_stats_stats.o: src/stats.c
+	$(CC) -c -o $@ $(CPPFLAGS) $(WERROR_CFLAGS) $(CFLAGS) \
+		-DTEST \
+		$(srcdir)/src/stats.c
 
 src/mon-gnome.o: src/mon-gnome.c
 	$(CC) -c -o $@ $(CPPFLAGS) $(CFLAGS) \

--- a/src/h_stats.c
+++ b/src/h_stats.c
@@ -1,0 +1,50 @@
+/* -*- c-file-style: "java"; indent-tabs-mode: nil; tab-width: 4; fill-column: 78 -*-
+ *
+ * distcc -- A simple distributed compiler system
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <config.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "dopt.h"
+#include "distcc.h"
+
+const char *rs_program_name = __FILE__;
+
+int arg_stats;
+int arg_stats_port;
+char *opt_listen_addr;
+struct dcc_allow_list *opt_allowed;
+int dcc_max_kids;
+
+void dcc_manage_kids(int listen_fd);
+int dcc_stats_test_prune_old_head(void);
+
+void dcc_manage_kids(int listen_fd) {
+    (void) listen_fd;
+}
+
+int main(int argc, char **argv) {
+    int ret;
+
+    if (argc != 2 || strcmp(argv[1], "prune-old-head") != 0) {
+        fprintf(stderr, "usage: %s prune-old-head\n", argv[0]);
+        return 1;
+    }
+
+    ret = dcc_stats_test_prune_old_head();
+    if (ret != 0) {
+        fprintf(stderr, "h_stats prune-old-head failed: %d\n", ret);
+        return ret;
+    }
+
+    puts("ok");
+    return 0;
+}

--- a/src/stats.c
+++ b/src/stats.c
@@ -169,14 +169,15 @@ static void dcc_stats_update_compile_times(struct statsdata *sd) {
     curr_sd = dcc_stats.sd_root;
     while (curr_sd != NULL) {
         if (curr_sd->stop.tv_sec < two_min_ago) {
+            struct statsdata *next_sd = curr_sd->next;
             /* delete the stat */
             if (prev_sd == NULL) {
-                dcc_stats.sd_root = curr_sd->next;
+                dcc_stats.sd_root = next_sd;
             } else {
-                prev_sd->next = curr_sd->next;
+                prev_sd->next = next_sd;
             }
             free(curr_sd);
-            curr_sd = prev_sd->next;
+            curr_sd = next_sd;
         } else {
             /* we didn't delete anything. move forward by one */
             prev_sd = curr_sd;
@@ -184,6 +185,54 @@ static void dcc_stats_update_compile_times(struct statsdata *sd) {
         }
     }
 }
+
+#ifdef TEST
+int dcc_stats_test_prune_old_head(void);
+
+int dcc_stats_test_prune_old_head(void) {
+    struct statsdata newer_sd;
+    struct statsdata older_sd;
+    time_t now = time(NULL);
+    int ret = 0;
+
+    memset(&dcc_stats, 0, sizeof(dcc_stats));
+
+    memset(&newer_sd, 0, sizeof(newer_sd));
+    newer_sd.type = STATS_COMPILE_OK;
+    newer_sd.start.tv_sec = now - 10;
+    newer_sd.stop.tv_sec = now - 5;
+    newer_sd.time = 1;
+    strncpy(newer_sd.filename, "newer.c", MAX_FILENAME_LEN - 1);
+    strncpy(newer_sd.compiler, "cc", MAX_FILENAME_LEN - 1);
+
+    memset(&older_sd, 0, sizeof(older_sd));
+    older_sd.type = STATS_COMPILE_OK;
+    older_sd.start.tv_sec = now - 200;
+    older_sd.stop.tv_sec = now - 180;
+    older_sd.time = 2;
+    strncpy(older_sd.filename, "older.c", MAX_FILENAME_LEN - 1);
+    strncpy(older_sd.compiler, "cc", MAX_FILENAME_LEN - 1);
+
+    dcc_stats_update_compile_times(&newer_sd);
+    dcc_stats_update_compile_times(&older_sd);
+
+    if (dcc_stats.sd_root == NULL) {
+        ret = 1;
+    } else if (dcc_stats.sd_root->next != NULL) {
+        ret = 2;
+    } else if (strcmp(dcc_stats.sd_root->filename, "newer.c") != 0) {
+        ret = 3;
+    }
+
+    while (dcc_stats.sd_root != NULL) {
+        struct statsdata *next_sd = dcc_stats.sd_root->next;
+        free(dcc_stats.sd_root);
+        dcc_stats.sd_root = next_sd;
+    }
+
+    return ret;
+}
+#endif
 
 /* caclulate the avg kids used */
 static void dcc_stats_calc_kid_avg(void) {

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -485,6 +485,13 @@ class StripArgs_Case(SimpleDistCC_Case):
             self.assert_equal(o, expect)
 
 
+class Stats_Case(SimpleDistCC_Case):
+    """Test distccd statistics list maintenance."""
+    def runtest(self):
+        out, err = self.runcmd("h_stats prune-old-head")
+        self.assert_equal(out.strip(), "ok")
+
+
 class IsSource_Case(SimpleDistCC_Case):
     def runtest(self):
         """Test distcc's method for working out whether a file is source"""


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Fixes #585.

## Summary

Fix pruning of stale compile-statistics entries when the stale entry is at the head of the list.

## What This Actually Changes

Before this pull request, the compile-statistics pruning code could mishandle the first entry in the linked list. When the oldest entry was also the head entry, the code freed the current node and then continued through a pointer path that was not valid for a head removal.

This pull request saves the next entry before unlinking and freeing the stale node. After pruning, iteration continues from the saved next entry instead of relying on a previous-node pointer that does not exist for the list head.

For users, this does not add a new option or change normal distcc scheduling. It makes the statistics maintenance path safer when old compile entries are removed.

## What this PR fixes

This fixes a stale statistics pruning bug in the distccd parent process.

The protected case is:

```text
old head entry -> newer entry -> newer entry
```

When the old head entry is pruned, the expected result is:

```text
newer entry -> newer entry
```

The wrong behavior is that pruning the old head can continue through invalid list state after the head has been freed. In the worst case, the distccd parent can crash while processing statistics.

## What changed in code

`src/stats.c` now stores `curr_sd->next` before unlinking and freeing the stale entry. That saved next pointer becomes the next iterator position after pruning.

`src/h_stats.c` adds a focused regression helper for the stale-head pruning path. `Makefile.in` builds the helper, and `test/testdistcc.py` registers `Stats_Case` so the behavior is covered by the test suite.

## Why this matters for users

The distccd parent process is responsible for accepting and managing compile jobs. A crash in parent-side statistics maintenance can look unrelated to the user's current compile command because it depends on background statistics state and timing.

That makes the failure hard to diagnose: a user may see distributed builds stop, workers disappear, or job accounting behave strangely even though the compile request itself is not malformed.

Fixing the head-pruning case keeps stale statistics cleanup from destabilizing the daemon. It also gives maintainers a direct regression test for the linked-list edge case that previously was easy to miss.

## Scope

This pull request is limited to compile-statistics pruning and focused regression coverage. It does not include release, container, RPM packaging, unrelated test-harness work, or unrelated Secure Shell warning fixes.

## Scope boundaries

This Pull Request is limited to distccd compile-statistics pruning when stale entries are removed from the head of the statistics list, plus the helper and regression test for that case. It does not change release metadata, package files, container files, compression behavior, or unrelated daemon scheduling behavior.

## Local Scope Evidence

The current branch only changes:

```text
Makefile.in
src/h_stats.c
src/stats.c
test/testdistcc.py
```

A scope check found no Docker, release workflow, RPM packaging, release-package helper, or `src/ssh.c` changes in this branch.

## Validation

Required before treating this as ready again:

```text
git diff --check
python3.13 -m py_compile test/testdistcc.py
./autogen.sh
PYTHON=/usr/bin/python3.13 ./configure --enable-Werror
make h_stats
./h_stats prune-old-head
make TESTNAME=Stats_Case single-test
make check
local leak scan
```

## Changelog

I accidentally changed this pull request while testing release and packaging work. Those unrelated changes have been reversed, and the branch has been restored to the original intended scope: compile-statistics stale-head pruning only.