### PR TITLE
testing: isolate no-detach daemon child waits

### DIFF
--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1572,6 +1572,16 @@ class NoDetachDaemon_Case(CompileHello_Case):
             return os.WEXITSTATUS(status)
         return status
 
+    def _canConnectToDaemon(self):
+        # Some platforms keep a refused connection state on a socket.  Use a
+        # fresh socket for each readiness probe so later daemon readiness is
+        # observed correctly.
+        sock = socket.socket()
+        try:
+            return sock.connect_ex(('127.0.0.1', self.server_port)) == 0
+        finally:
+            sock.close()
+
     def startDaemon(self):
         max_start_attempts = 5
         attempts = 0
@@ -1599,9 +1609,24 @@ class NoDetachDaemon_Case(CompileHello_Case):
             # same port when the daemon exits with EXIT_BIND_FAILED.
             deadline = time.time() + 30
             retry = False
-            sock = socket.socket()
-            try:
-                while sock.connect_ex(('127.0.0.1', self.server_port)) != 0:
+            while not self._canConnectToDaemon():
+                result = self._collectDaemonStartupFailure()
+                if result is not None:
+                    if result == EXIT_BIND_FAILED:
+                        self.server_port += 1
+                        retry = True
+                        break
+                    self.fail("failed to start daemon: %d" % result)
+                if time.time() > deadline:
+                    self.log("distccd log before startup timeout:\n%s" %
+                             self._readDaemonLog())
+                    self.killDaemon()
+                    self.server_port += 1
+                    retry = True
+                    break
+                time.sleep(0.2)
+            else:
+                while not os.path.exists(self.daemon_pidfile):
                     result = self._collectDaemonStartupFailure()
                     if result is not None:
                         if result == EXIT_BIND_FAILED:
@@ -1610,36 +1635,17 @@ class NoDetachDaemon_Case(CompileHello_Case):
                             break
                         self.fail("failed to start daemon: %d" % result)
                     if time.time() > deadline:
-                        self.log("distccd log before startup timeout:\n%s" %
+                        self.log("distccd log before pidfile timeout:\n%s" %
                                  self._readDaemonLog())
                         self.killDaemon()
                         self.server_port += 1
                         retry = True
                         break
                     time.sleep(0.2)
-                else:
-                    while not os.path.exists(self.daemon_pidfile):
-                        result = self._collectDaemonStartupFailure()
-                        if result is not None:
-                            if result == EXIT_BIND_FAILED:
-                                self.server_port += 1
-                                retry = True
-                                break
-                            self.fail("failed to start daemon: %d" % result)
-                        if time.time() > deadline:
-                            self.log("distccd log before pidfile timeout:\n%s" %
-                                     self._readDaemonLog())
-                            self.killDaemon()
-                            self.server_port += 1
-                            retry = True
-                            break
-                        time.sleep(0.2)
-                    if retry:
-                        continue
-                    self.add_cleanup(self.killDaemon)
-                    return
-            finally:
-                sock.close()
+                if retry:
+                    continue
+                self.add_cleanup(self.killDaemon)
+                return
             if retry:
                 continue
         self.log("distccd log after startup attempts:\n%s" %

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1567,7 +1567,10 @@ class NoDetachDaemon_Case(CompileHello_Case):
         return status
 
     def startDaemon(self):
-        while 1:
+        max_start_attempts = 5
+        attempts = 0
+        while attempts < max_start_attempts:
+            attempts += 1
             try:
                 os.remove(self.daemon_pidfile)
             except OSError:
@@ -1600,7 +1603,9 @@ class NoDetachDaemon_Case(CompileHello_Case):
                         self.fail("failed to start daemon: %d" % result)
                     if time.time() > deadline:
                         self.killDaemon()
-                        self.fail("timed out waiting for daemon startup")
+                        self.server_port += 1
+                        retry = True
+                        break
                     time.sleep(0.2)
                 else:
                     while not os.path.exists(self.daemon_pidfile):
@@ -1613,7 +1618,9 @@ class NoDetachDaemon_Case(CompileHello_Case):
                             self.fail("failed to start daemon: %d" % result)
                         if time.time() > deadline:
                             self.killDaemon()
-                            self.fail("timed out waiting for daemon pidfile")
+                            self.server_port += 1
+                            retry = True
+                            break
                         time.sleep(0.2)
                     if retry:
                         continue
@@ -1623,6 +1630,7 @@ class NoDetachDaemon_Case(CompileHello_Case):
                 sock.close()
             if retry:
                 continue
+        self.fail("failed to start daemon after %d attempts" % max_start_attempts)
 
     def killDaemon(self):
         # Terminate the process specified by the pidfile.  That should kill

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1559,31 +1559,58 @@ large foo!
 class NoDetachDaemon_Case(CompileHello_Case):
     """Test the --no-detach option."""
     def startDaemon(self):
-        # FIXME: This  does not work well if it happens to get the same
-        # port as an existing server, because we can't catch the error.
-        cmd = (self.distccd() +
-               "--no-detach --daemon --verbose --log-file %s --pid-file %s "
-               "--port %d --allow 127.0.0.1 --enable-tcp-insecure --sysroot %s" %
-               (_ShellSafe(self.daemon_logfile),
-                _ShellSafe(self.daemon_pidfile),
-                self.server_port,
-                _ShellSafe(self.daemon_sysroot)))
-        self.pid = self.runcmd_background(cmd)
-        self.add_cleanup(self.killDaemon)
-        # Wait until the server is ready for connections.
-        time.sleep(0.2)   # Give distccd chance to start listening on the port
-        sock = socket.socket()
-        while sock.connect_ex(('127.0.0.1', self.server_port)) != 0:
-            time.sleep(0.2)
+        while 1:
+            cmd = (self.distccd() +
+                   "--no-detach --daemon --verbose --log-file %s --pid-file %s "
+                   "--port %d --allow 127.0.0.1 --enable-tcp-insecure --sysroot %s" %
+                   (_ShellSafe(self.daemon_logfile),
+                    _ShellSafe(self.daemon_pidfile),
+                    self.server_port,
+                    _ShellSafe(self.daemon_sysroot)))
+            self.pid = self.runcmd_background(cmd)
+
+            # Wait until the server is ready for connections, while also
+            # collecting early startup failures from the no-detach process.
+            deadline = time.time() + 10
+            sock = socket.socket()
+            try:
+                while sock.connect_ex(('127.0.0.1', self.server_port)) != 0:
+                    pid, status = os.waitpid(self.pid, os.WNOHANG)
+                    if pid:
+                        if os.WIFEXITED(status):
+                            result = os.WEXITSTATUS(status)
+                        else:
+                            result = status
+                        if result == EXIT_BIND_FAILED:
+                            self.server_port += 1
+                            break
+                        self.fail("failed to start daemon: %d" % result)
+                    if time.time() > deadline:
+                        self.killDaemon()
+                        self.fail("timed out waiting for daemon startup")
+                    time.sleep(0.2)
+                else:
+                    self.add_cleanup(self.killDaemon)
+                    return
+            finally:
+                sock.close()
 
     def killDaemon(self):
         # Terminate the process specified by the pidfile.  That should kill
         # the distccd process, any child distccd processes and the shell
         # process used to launch distccd.
-        daemon_pid = int(open(self.daemon_pidfile, 'rt').read())
+        try:
+            daemon_pid = int(open(self.daemon_pidfile, 'rt').read())
+        except IOError:
+            try:
+                os.kill(self.pid, signal.SIGTERM)
+                os.waitpid(self.pid, 0)
+            except OSError:
+                pass
+            return
         os.kill(daemon_pid, signal.SIGTERM)
 
-        pid, ret = os.wait()
+        pid, ret = os.waitpid(self.pid, 0)
         self.assert_equal(self.pid, pid)
 
 
@@ -1816,7 +1843,8 @@ class Concurrent_Case(CompileHello_Case):
                                          self._cc + " -o testtmp.o -c testtmp.c")
             pids[kid] = kid
         while len(pids):
-            pid, status = os.wait()
+            pid = next(iter(pids))
+            pid, status = os.waitpid(pid, 0)
             if status:
                 self.fail("child %d failed with status %#x" % (pid, status))
             del pids[pid]

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1558,8 +1558,21 @@ large foo!
 
 class NoDetachDaemon_Case(CompileHello_Case):
     """Test the --no-detach option."""
+    def _collectDaemonStartupFailure(self):
+        pid, status = os.waitpid(self.pid, os.WNOHANG)
+        if not pid:
+            return None
+        if os.WIFEXITED(status):
+            return os.WEXITSTATUS(status)
+        return status
+
     def startDaemon(self):
         while 1:
+            try:
+                os.remove(self.daemon_pidfile)
+            except OSError:
+                pass
+
             cmd = (self.distccd() +
                    "--no-detach --daemon --verbose --log-file %s --pid-file %s "
                    "--port %d --allow 127.0.0.1 --enable-tcp-insecure --sysroot %s" %
@@ -1571,18 +1584,18 @@ class NoDetachDaemon_Case(CompileHello_Case):
 
             # Wait until the server is ready for connections, while also
             # collecting early startup failures from the no-detach process.
+            # The pidfile check avoids accepting an unrelated listener on the
+            # same port when the daemon exits with EXIT_BIND_FAILED.
             deadline = time.time() + 10
+            retry = False
             sock = socket.socket()
             try:
                 while sock.connect_ex(('127.0.0.1', self.server_port)) != 0:
-                    pid, status = os.waitpid(self.pid, os.WNOHANG)
-                    if pid:
-                        if os.WIFEXITED(status):
-                            result = os.WEXITSTATUS(status)
-                        else:
-                            result = status
+                    result = self._collectDaemonStartupFailure()
+                    if result is not None:
                         if result == EXIT_BIND_FAILED:
                             self.server_port += 1
+                            retry = True
                             break
                         self.fail("failed to start daemon: %d" % result)
                     if time.time() > deadline:
@@ -1590,10 +1603,26 @@ class NoDetachDaemon_Case(CompileHello_Case):
                         self.fail("timed out waiting for daemon startup")
                     time.sleep(0.2)
                 else:
+                    while not os.path.exists(self.daemon_pidfile):
+                        result = self._collectDaemonStartupFailure()
+                        if result is not None:
+                            if result == EXIT_BIND_FAILED:
+                                self.server_port += 1
+                                retry = True
+                                break
+                            self.fail("failed to start daemon: %d" % result)
+                        if time.time() > deadline:
+                            self.killDaemon()
+                            self.fail("timed out waiting for daemon pidfile")
+                        time.sleep(0.2)
+                    if retry:
+                        continue
                     self.add_cleanup(self.killDaemon)
                     return
             finally:
                 sock.close()
+            if retry:
+                continue
 
     def killDaemon(self):
         # Terminate the process specified by the pidfile.  That should kill

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1586,7 +1586,7 @@ class NoDetachDaemon_Case(CompileHello_Case):
             # collecting early startup failures from the no-detach process.
             # The pidfile check avoids accepting an unrelated listener on the
             # same port when the daemon exits with EXIT_BIND_FAILED.
-            deadline = time.time() + 10
+            deadline = time.time() + 30
             retry = False
             sock = socket.socket()
             try:

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1576,9 +1576,11 @@ class NoDetachDaemon_Case(CompileHello_Case):
             except OSError:
                 pass
 
+            # Bind to the same loopback address family that this test probes.
             cmd = (self.distccd() +
                    "--no-detach --daemon --verbose --log-file %s --pid-file %s "
-                   "--port %d --allow 127.0.0.1 --enable-tcp-insecure --sysroot %s" %
+                   "--port %d --listen 127.0.0.1 --allow 127.0.0.1 "
+                   "--enable-tcp-insecure --sysroot %s" %
                    (_ShellSafe(self.daemon_logfile),
                     _ShellSafe(self.daemon_pidfile),
                     self.server_port,

--- a/test/testdistcc.py
+++ b/test/testdistcc.py
@@ -1558,6 +1558,12 @@ large foo!
 
 class NoDetachDaemon_Case(CompileHello_Case):
     """Test the --no-detach option."""
+    def _readDaemonLog(self):
+        try:
+            return open(self.daemon_logfile, 'rt').read()
+        except IOError as e:
+            return "could not read daemon log: %s" % e
+
     def _collectDaemonStartupFailure(self):
         pid, status = os.waitpid(self.pid, os.WNOHANG)
         if not pid:
@@ -1604,6 +1610,8 @@ class NoDetachDaemon_Case(CompileHello_Case):
                             break
                         self.fail("failed to start daemon: %d" % result)
                     if time.time() > deadline:
+                        self.log("distccd log before startup timeout:\n%s" %
+                                 self._readDaemonLog())
                         self.killDaemon()
                         self.server_port += 1
                         retry = True
@@ -1619,6 +1627,8 @@ class NoDetachDaemon_Case(CompileHello_Case):
                                 break
                             self.fail("failed to start daemon: %d" % result)
                         if time.time() > deadline:
+                            self.log("distccd log before pidfile timeout:\n%s" %
+                                     self._readDaemonLog())
                             self.killDaemon()
                             self.server_port += 1
                             retry = True
@@ -1632,6 +1642,8 @@ class NoDetachDaemon_Case(CompileHello_Case):
                 sock.close()
             if retry:
                 continue
+        self.log("distccd log after startup attempts:\n%s" %
+                 self._readDaemonLog())
         self.fail("failed to start daemon after %d attempts" % max_start_attempts)
 
     def killDaemon(self):


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Fixes #593.

## Summary

This Pull Request cleans up the no-detach daemon test harness so the tests wait for the right child processes and report daemon startup failures directly.

This is test infrastructure work, not a runtime distcc behavior change. The goal is to make the existing tests reliable enough that CI failures point to the real failing condition instead of being caused by leaked child process state, stale pidfiles, reused readiness sockets, or hidden daemon startup logs.

## What This Actually Changes

`NoDetachDaemon_Case` now owns the daemon startup path more strictly. It removes stale pidfiles before retry attempts, requires the daemon pidfile after socket readiness, reports no-detach daemon logs when startup fails, and retries the specific bind-failure case that can happen when a just-started daemon loses the port race.

`Concurrent_Case` no longer depends on process-global child waiting behavior from unrelated tests. The test harness is adjusted so each test case waits for the children it started instead of letting one test accidentally consume another test's child status.

The readiness loop also uses fresh socket probes. That matters on systems where reusing one socket after an early refused connection can fail to observe a daemon that becomes ready shortly afterward.

## What this PR fixes

The expected test-harness behavior is:

```text
NoDetachDaemon_Case starts daemon -> waits for that daemon -> checks readiness -> reports that daemon's logs on failure
Concurrent_Case starts its children -> waits for those children only
```

The unsafe behavior is:

```text
one test leaves or consumes child process state globally -> another test sees the wrong state -> CI fails for the wrong reason
```

Another unsafe behavior is:

```text
readiness check sees early connection refused -> reused probe does not observe later readiness -> test fails even though daemon became ready
```

The new behavior keeps the failure closer to the real cause: daemon could not start, daemon did not become ready, or the test's own child process failed.

## What changed in code

All code changes are in `test/testdistcc.py`. The patch updates no-detach daemon startup handling, pidfile cleanup, readiness probing, retry behavior, failure logging, and child waiting in the affected test cases.

There are no source changes to `distccd`, pump, the include server, compression, package metadata, release metadata, or container files in this Pull Request.

## Why this matters for users

Users do not get a new command-line option or runtime behavior from this Pull Request. The value is that CI becomes less noisy and more trustworthy. When CI reports a failure, maintainers should be able to spend time on the actual regression instead of first proving that the test harness waited for the wrong process.

This matters for downstream users too because reliable tests reduce the chance that real regressions are missed or that useful patches are delayed by false failures.

## Scope boundaries

This Pull Request is limited to no-detach daemon test-harness isolation and readiness handling. It does not add release metadata, package files, container files, RPM or Debian packaging changes, compression changes, or runtime daemon feature changes.

## Local Scope Evidence

Current branch scope is limited to this file:

```text
test/testdistcc.py
```

No Dockerfile, release workflow, RPM spec, Debian packaging file, container entrypoint file, pump source file, include-server source file, or distccd runtime source file is part of this Pull Request.

## Validation

Local validation for this branch should include the no-detach daemon tests and concurrent child-process tests touched by `test/testdistcc.py`. A failed startup, hidden daemon log, child wait mismatch, readiness timeout, or command warning must be treated as a failed validation result.

## Changelog

I accidentally changed this Pull Request while testing release and packaging work. Those unrelated changes have been reversed, and the branch has been restored to the original intended scope: no-detach daemon test-harness isolation only.