### PR TITLE
remote shell: use constant ssh argument bound

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -193,9 +193,9 @@ int dcc_ssh_connect(char *ssh_cmd,
                     pid_t *ssh_pid)
 {
     pid_t ret;
-    const int max_ssh_args = 12;
-    char *ssh_args[max_ssh_args];
-    char *child_argv[11+max_ssh_args];
+    enum { MAX_SSH_ARGS = 12 };
+    char *ssh_args[MAX_SSH_ARGS];
+    char *child_argv[11 + MAX_SSH_ARGS];
     int i,j;
     int num_ssh_args = 0;
     char *ssh_cmd_in;
@@ -209,7 +209,7 @@ int dcc_ssh_connect(char *ssh_cmd,
         while (token != NULL) {
             ssh_args[num_ssh_args++] = token;
             token = strtok(NULL, " ");
-            if (num_ssh_args == max_ssh_args)
+            if (num_ssh_args == MAX_SSH_ARGS)
                 break;
         }
     }


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Fixes #595.

## Summary

Use a local C compile-time constant for the Secure Shell argument array bound in `src/ssh.c`.

This is a compiler-compatibility fix for Apple clang with warnings as errors. It does not change the Secure Shell argument limit or runtime behavior.

## What This Actually Changes

Before this Pull Request, `dcc_ssh_connect()` used a function-local `const int` as an array bound:

```c
const int max_ssh_args = 12;
char *ssh_args[max_ssh_args];
char *child_argv[11+max_ssh_args];
```

Apple clang can fold that value but still warns that the arrays are variable length arrays as an extension. With `-Werror`, that warning becomes a build failure.

This Pull Request replaces the function-local `const int` with an `enum` compile-time constant and uses that constant for the same array bounds and argument-count check.

## What this PR fixes

The build failure is:

```text
src/ssh.c:197:20: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
src/ssh.c:198:22: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
```

The expected result is that `src/ssh.c` compiles cleanly with Apple clang when warnings are treated as errors.

## What changed in code

Only `src/ssh.c` changes. The local bound becomes an `enum` constant and the existing arrays and bounds check continue to use the same numeric limit.

## Why not a preprocessor define

A `#define` would also work mechanically, but it is global preprocessor text substitution and can introduce broader scope and readability risks.

An `enum` constant is a C-idiomatic compile-time constant for this pattern. It keeps the name in C scope, avoids macro side effects, and makes the intent clear next to the arrays that need a compile-time bound.

## Why this matters for users

This warning can block CI before unrelated Pull Requests reach their tests. Keeping the source warning-clean under `-Werror` makes the build more portable and prevents a compiler-specific warning from hiding the result of other changes.

## Scope boundaries

This Pull Request is limited to the local Secure Shell argument bound in `src/ssh.c`. It does not change Secure Shell option parsing, argument propagation, pump behavior, package files, release files, or container files.

## Validation

Local validation:

```text
./autogen.sh
./configure --enable-Werror
make src/ssh.o
git diff --check
local leak scan
```