### PR TITLE
pump: resolve installed include server path

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -698,7 +698,7 @@ TESTDISTCC_OPTS =
 # TODO(klarlund): the outermost if assumes that the include-server target may be
 # satisfied w/o actually building an include server (or rather the C extension);
 # this logic needs to be verified or amended.
-maintainer-check-no-set-path:
+maintainer-check-no-set-path: pump
 	@if ! $(PYTHON) -c 'import sys; print(sys.version)'; then \
 	  echo "WARNING: python not found; tests skipped"; \
 	else \

--- a/Makefile.in
+++ b/Makefile.in
@@ -201,6 +201,7 @@ man8dir = $(mandir)/man8
 
 test_SOURCE = test/comfychair.py \
 	test/onetest.py \
+	test/pump_include_server_path_test.py \
 	test/testdistcc.py \
 	find_c_extension.sh
 
@@ -708,7 +709,9 @@ maintainer-check-no-set-path:
 	    echo "Please change RESTRICTED_PATH to change this PATH value."; \
 	    exit 1; \
 	  fi; \
-	  $(PYTHON) "$(srcdir)/test/testdistcc.py" $(TESTDISTCC_OPTS); \
+	  $(PYTHON) "$(srcdir)/test/testdistcc.py" $(TESTDISTCC_OPTS) && \
+	  $(PYTHON) "$(srcdir)/test/pump_include_server_path_test.py" \
+	    "$(builddir)/pump" "$(PYTHON)"; \
 	fi
 
 distcc-maintainer-check: check_programs

--- a/pump.in
+++ b/pump.in
@@ -217,6 +217,56 @@ PrintIncludeServerStatusMessage() {
   fi
 }
 
+PythonMajorMinorVersion() {
+  "$PYTHON" -c 'import sys; print("%d.%d" % sys.version_info[:2])'
+}
+
+ResolveInstalledIncludeServer() {
+  if [ -n "$include_server" ] && [ -f "$include_server" ]; then
+    return 0
+  fi
+
+  python_version=`PythonMajorMinorVersion` || {
+    echo "$program_name: error: can't determine Python version from $PYTHON" \
+      1>&2
+    return 1
+  }
+
+  distcc_parent=`dirname "$distcc_location"`
+
+  # Prefer the Python version used to configure this pump script.  This keeps
+  # path resolution deterministic when multiple Python versions are installed.
+  for candidate in \
+    "$prefix/lib/python$python_version/dist-packages/include_server/include_server.py" \
+    "$prefix/lib/python$python_version/site-packages/include_server/include_server.py" \
+    "$exec_prefix/lib/python$python_version/dist-packages/include_server/include_server.py" \
+    "$exec_prefix/lib/python$python_version/site-packages/include_server/include_server.py" \
+    "$distcc_parent/lib/python$python_version/dist-packages/include_server/include_server.py" \
+    "$distcc_parent/lib/python$python_version/site-packages/include_server/include_server.py" \
+    "$prefix/lib/distcc-pump/lib/python$python_version/dist-packages/include_server/include_server.py" \
+    "$prefix/lib/distcc-pump/lib/python$python_version/site-packages/include_server/include_server.py" \
+    "$exec_prefix/lib/distcc-pump/lib/python$python_version/dist-packages/include_server/include_server.py" \
+    "$exec_prefix/lib/distcc-pump/lib/python$python_version/site-packages/include_server/include_server.py" \
+    "$distcc_parent/lib/distcc-pump/lib/python$python_version/dist-packages/include_server/include_server.py" \
+    "$distcc_parent/lib/distcc-pump/lib/python$python_version/site-packages/include_server/include_server.py"
+  do
+    if [ -f "$candidate" ]; then
+      include_server="$candidate"
+      return 0
+    fi
+  done
+
+  if [ -n "$include_server" ]; then
+    echo "$program_name: error: can't find include_server.py at" \
+      "'$include_server' or under the Python $python_version install paths" \
+      1>&2
+  else
+    echo "$program_name: error: can't find include_server.py under the" \
+      "Python $python_version install paths" 1>&2
+  fi
+  return 1
+}
+
 Announce() {
   if [ "$verbose" = 1 ]; then
     echo "__________Using distcc-pump from $DISTCC_LOCATION"
@@ -232,6 +282,7 @@ StartIncludeServer() {
   # installed pump (in /usr/local/bin somewhere or something), and
   # include_server points to the installed include_server.py.
   if [ -n "$include_server" ]; then
+    ResolveInstalledIncludeServer || return 1
     pythonpath=`dirname "$include_server"`
   else
     # We assume this script is run from the build directory.  We pick up .py

--- a/pump.in
+++ b/pump.in
@@ -221,6 +221,40 @@ PythonMajorMinorVersion() {
   "$PYTHON" -c 'import sys; print("%d.%d" % sys.version_info[:2])'
 }
 
+PythonIncludeServerCandidatePaths() {
+  "$PYTHON" - "$python_version" "$prefix" "$exec_prefix" "$distcc_parent" <<'PY'
+import sys
+import sysconfig
+
+version = sys.argv[1]
+roots = sys.argv[2:]
+python_version = "python%s" % version
+python_path_suffix = "/%s/" % python_version
+
+for root in roots:
+  if not root:
+    continue
+  for location in ("purelib", "platlib"):
+    libdir = sysconfig.get_path(
+        location, vars={"base": root, "platbase": root, "data": root})
+    if not libdir:
+      continue
+    print("%s/include_server/include_server.py" % libdir)
+    split_point = libdir.find(python_path_suffix)
+    if split_point == -1:
+      continue
+    python_root = libdir[:split_point]
+    remainder = libdir[split_point + len(python_path_suffix):]
+    if remainder:
+      print(
+          "%s/distcc-pump/%s/%s/include_server/include_server.py" %
+          (python_root.rstrip("/"), python_version, remainder))
+    else:
+      print("%s/distcc-pump/%s/include_server/include_server.py" %
+            (python_root.rstrip("/"), python_version))
+PY
+}
+
 ResolveInstalledIncludeServer() {
   if [ -n "$include_server" ] && [ -f "$include_server" ]; then
     return 0
@@ -234,27 +268,28 @@ ResolveInstalledIncludeServer() {
 
   distcc_parent=`dirname "$distcc_location"`
 
-  # Prefer the Python version used to configure this pump script.  This keeps
-  # path resolution deterministic when multiple Python versions are installed.
-  for candidate in \
-    "$prefix/lib/python$python_version/dist-packages/include_server/include_server.py" \
-    "$prefix/lib/python$python_version/site-packages/include_server/include_server.py" \
-    "$exec_prefix/lib/python$python_version/dist-packages/include_server/include_server.py" \
-    "$exec_prefix/lib/python$python_version/site-packages/include_server/include_server.py" \
-    "$distcc_parent/lib/python$python_version/dist-packages/include_server/include_server.py" \
-    "$distcc_parent/lib/python$python_version/site-packages/include_server/include_server.py" \
-    "$prefix/lib/distcc-pump/lib/python$python_version/dist-packages/include_server/include_server.py" \
-    "$prefix/lib/distcc-pump/lib/python$python_version/site-packages/include_server/include_server.py" \
-    "$exec_prefix/lib/distcc-pump/lib/python$python_version/dist-packages/include_server/include_server.py" \
-    "$exec_prefix/lib/distcc-pump/lib/python$python_version/site-packages/include_server/include_server.py" \
-    "$distcc_parent/lib/distcc-pump/lib/python$python_version/dist-packages/include_server/include_server.py" \
-    "$distcc_parent/lib/distcc-pump/lib/python$python_version/site-packages/include_server/include_server.py"
+  candidate_file=`mktemp "${TMPDIR:-/tmp}/distcc-pump-candidates.XXXXXX"` || {
+    echo "$program_name: error: can't create include_server candidate list" \
+      1>&2
+    return 1
+  }
+  if ! PythonIncludeServerCandidatePaths > "$candidate_file"; then
+    rm -f "$candidate_file"
+    echo "$program_name: error: can't query Python include_server paths" 1>&2
+    return 1
+  fi
+
+  # Prefer the Python version used to configure this pump script.  Reading the
+  # generated list line-by-line keeps paths with whitespace intact.
+  while IFS= read -r candidate
   do
     if [ -f "$candidate" ]; then
       include_server="$candidate"
+      rm -f "$candidate_file"
       return 0
     fi
-  done
+  done < "$candidate_file"
+  rm -f "$candidate_file"
 
   if [ -n "$include_server" ]; then
     echo "$program_name: error: can't find include_server.py at" \

--- a/test/pump_include_server_path_test.py
+++ b/test/pump_include_server_path_test.py
@@ -10,10 +10,53 @@
 """Regression test for installed pump include_server path resolution."""
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
+
+
+def BuildFakeIncludeServerPathCandidates(python, version, *search_roots):
+    script = """
+import sys
+import sysconfig
+
+version = sys.argv[1]
+search_roots = sys.argv[2:]
+python_version = 'python' + version
+marker = '/%s/' % python_version
+
+for search_root in search_roots:
+  if not search_root:
+    continue
+  for path_type in ('purelib', 'platlib'):
+    lib_dir = sysconfig.get_path(
+        path_type, vars={'base': search_root, 'platbase': search_root,
+                         'data': search_root})
+    if not lib_dir:
+      continue
+    print('%s/include_server/include_server.py' % lib_dir)
+    marker_pos = lib_dir.find(marker)
+    if marker_pos == -1:
+      continue
+    python_root = lib_dir[:marker_pos]
+    remainder = lib_dir[marker_pos + len(marker):]
+    if remainder:
+      print('%s/distcc-pump/%s/%s/include_server/include_server.py' %
+            (python_root.rstrip('/'), python_version, remainder))
+    else:
+      print('%s/distcc-pump/%s/include_server/include_server.py' %
+            (python_root.rstrip('/'), python_version))
+"""
+    output = subprocess.check_output(
+        [python, "-c", script, version] + list(search_roots),
+        universal_newlines=True)
+    candidates = []
+    for path in output.splitlines():
+        if path and path not in candidates:
+            candidates.append(path)
+    return candidates
 
 
 def WriteExecutable(path, contents):
@@ -43,24 +86,34 @@ def MakeFakeIncludeServer(path):
         import os
         import signal
         import socket
+        import sys
         import time
 
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--port", required=True)
-        parser.add_argument("--pid_file", required=True)
-        parser.add_argument("-d1", action="store_true")
-        args, _ = parser.parse_known_args()
+        port = None
+        pid_file_path = None
+        index = 1
+        while index < len(sys.argv):
+            if sys.argv[index] == "--port":
+                port = sys.argv[index + 1]
+                index += 2
+            elif sys.argv[index] == "--pid_file":
+                pid_file_path = sys.argv[index + 1]
+                index += 2
+            else:
+                index += 1
+        if not port or not pid_file_path:
+            raise SystemExit(2)
 
         child_pid = os.fork()
         if child_pid:
             for _ in range(100):
-                if os.path.exists(args.port) and os.path.exists(args.pid_file):
+                if os.path.exists(port) and os.path.exists(pid_file_path):
                     raise SystemExit(0)
                 time.sleep(0.01)
             raise SystemExit(1)
 
         server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        server_socket.bind(args.port)
+        server_socket.bind(port)
         server_socket.listen(1)
 
         def handle_signal(_signum, _frame):
@@ -69,7 +122,7 @@ def MakeFakeIncludeServer(path):
 
         signal.signal(signal.SIGTERM, handle_signal)
 
-        with open(args.pid_file, "w", encoding="utf-8") as pid_file:
+        with open(pid_file_path, "w") as pid_file:
             pid_file.write(str(os.getpid()))
 
         while True:
@@ -85,18 +138,21 @@ def Main():
     python = sys.argv[2]
     version = subprocess.check_output(
         [python, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
-        text=True).strip()
+        universal_newlines=True).strip()
 
-    with tempfile.TemporaryDirectory(prefix="distcc-pump-path-test.") as tempdir:
+    tempdir = tempfile.mkdtemp(prefix="distcc-pump-path-test.")
+    try:
         bindir = os.path.join(tempdir, "bin")
         prefix = os.path.join(tempdir, "prefix")
-        include_server_dir = os.path.join(
-            prefix, "lib", "python%s" % version, "dist-packages",
-            "include_server")
         os.makedirs(bindir)
-        os.makedirs(include_server_dir)
+        include_server_paths = BuildFakeIncludeServerPathCandidates(
+            python, version, prefix, os.path.dirname(bindir))
+        for include_server_path in include_server_paths:
+            include_server_dir = os.path.dirname(include_server_path)
+            if not os.path.isdir(include_server_dir):
+                os.makedirs(include_server_dir)
 
-        with open(pump_template, encoding="utf-8") as input_file:
+        with open(pump_template) as input_file:
             pump_contents = input_file.read()
         pump_contents = ReplaceLine(
             pump_contents, "prefix=", "prefix=%s" % prefix)
@@ -114,24 +170,37 @@ def Main():
             exit 0
             """))
 
-        MakeFakeIncludeServer(
-            os.path.join(include_server_dir, "include_server.py"))
+        for include_server_path in include_server_paths:
+            MakeFakeIncludeServer(include_server_path)
 
         env = os.environ.copy()
+        for key in (
+            "DISTCC_FALLBACK",
+            "DISTCC_HOSTS",
+            "DISTCC_LOCATION",
+            "DISTCC_MAX_DISCREPANCY",
+            "DISTCC_POTENTIAL_HOSTS",
+            "INCLUDE_SERVER_ARGS",
+            "LSDISTCC_ARGS",
+        ):
+            env.pop(key, None)
         env["DISTCC_LOCATION"] = bindir
         env["DISTCC_HOSTS"] = "localhost,lzo,cpp"
 
-        result = subprocess.run(
+        process = subprocess.Popen(
             [os.path.join(bindir, "pump"), "echo", "ok"],
-            env=env, text=True, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, check=False)
+            env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
+        stdout, stderr = process.communicate()
 
-        if result.returncode != 0:
+        if process.returncode != 0:
             raise AssertionError(
                 "pump failed with status %d\nstdout:\n%s\nstderr:\n%s" %
-                (result.returncode, result.stdout, result.stderr))
-        if "ok\n" not in result.stdout:
+                (process.returncode, stdout, stderr))
+        if "ok\n" not in stdout:
             raise AssertionError("pump did not run the wrapped command")
+    finally:
+        shutil.rmtree(tempdir)
 
 
 if __name__ == "__main__":

--- a/test/pump_include_server_path_test.py
+++ b/test/pump_include_server_path_test.py
@@ -19,7 +19,7 @@ import textwrap
 def WriteExecutable(path, contents):
     with open(path, "w", encoding="utf-8") as output:
         output.write(contents)
-    os.chmod(path, 0o755)
+    os.chmod(path, 0o700)
 
 
 def ReplaceLine(contents, prefix, replacement):

--- a/test/pump_include_server_path_test.py
+++ b/test/pump_include_server_path_test.py
@@ -1,0 +1,138 @@
+#! /usr/bin/env python3
+
+# Copyright 2026 distcc contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+"""Regression test for installed pump include_server path resolution."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+def WriteExecutable(path, contents):
+    with open(path, "w", encoding="utf-8") as output:
+        output.write(contents)
+    os.chmod(path, 0o755)
+
+
+def ReplaceLine(contents, prefix, replacement):
+    lines = []
+    replaced = False
+    for line in contents.splitlines():
+        if line.startswith(prefix):
+            lines.append(replacement)
+            replaced = True
+        else:
+            lines.append(line)
+    if not replaced:
+        raise AssertionError("Could not replace line starting with %r" % prefix)
+    return "\n".join(lines) + "\n"
+
+
+def MakeFakeIncludeServer(path):
+    WriteExecutable(path, textwrap.dedent("""\
+        #! /usr/bin/env python3
+        import argparse
+        import os
+        import signal
+        import socket
+        import time
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--port", required=True)
+        parser.add_argument("--pid_file", required=True)
+        parser.add_argument("-d1", action="store_true")
+        args, _ = parser.parse_known_args()
+
+        child_pid = os.fork()
+        if child_pid:
+            for _ in range(100):
+                if os.path.exists(args.port) and os.path.exists(args.pid_file):
+                    raise SystemExit(0)
+                time.sleep(0.01)
+            raise SystemExit(1)
+
+        server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server_socket.bind(args.port)
+        server_socket.listen(1)
+
+        def handle_signal(_signum, _frame):
+            server_socket.close()
+            raise SystemExit(0)
+
+        signal.signal(signal.SIGTERM, handle_signal)
+
+        with open(args.pid_file, "w", encoding="utf-8") as pid_file:
+            pid_file.write(str(os.getpid()))
+
+        while True:
+            time.sleep(1)
+        """))
+
+
+def Main():
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: pump_include_server_path_test.py PUMP PYTHON")
+
+    pump_template = sys.argv[1]
+    python = sys.argv[2]
+    version = subprocess.check_output(
+        [python, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+        text=True).strip()
+
+    with tempfile.TemporaryDirectory(prefix="distcc-pump-path-test.") as tempdir:
+        bindir = os.path.join(tempdir, "bin")
+        prefix = os.path.join(tempdir, "prefix")
+        include_server_dir = os.path.join(
+            prefix, "lib", "python%s" % version, "dist-packages",
+            "include_server")
+        os.makedirs(bindir)
+        os.makedirs(include_server_dir)
+
+        with open(pump_template, encoding="utf-8") as input_file:
+            pump_contents = input_file.read()
+        pump_contents = ReplaceLine(
+            pump_contents, "prefix=", "prefix=%s" % prefix)
+        pump_contents = ReplaceLine(
+            pump_contents, "include_server=",
+            "include_server='/missing/include_server.py'")
+        WriteExecutable(os.path.join(bindir, "pump"), pump_contents)
+
+        WriteExecutable(os.path.join(bindir, "distcc"), textwrap.dedent("""\
+            #! /bin/sh
+            if [ "$1" = "--show-hosts" ]; then
+              echo localhost,lzo,cpp
+              exit 0
+            fi
+            exit 0
+            """))
+
+        MakeFakeIncludeServer(
+            os.path.join(include_server_dir, "include_server.py"))
+
+        env = os.environ.copy()
+        env["DISTCC_LOCATION"] = bindir
+        env["DISTCC_HOSTS"] = "localhost,lzo,cpp"
+
+        result = subprocess.run(
+            [os.path.join(bindir, "pump"), "echo", "ok"],
+            env=env, text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=False)
+
+        if result.returncode != 0:
+            raise AssertionError(
+                "pump failed with status %d\nstdout:\n%s\nstderr:\n%s" %
+                (result.returncode, result.stdout, result.stderr))
+        if "ok\n" not in result.stdout:
+            raise AssertionError("pump did not run the wrapped command")
+
+
+if __name__ == "__main__":
+    Main()


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance. I reviewed and tested the result, but the implementation was/will (be) largely AI-generated.

Fixes #579.

## Summary

This is a clean resubmission of #586 with the scope reduced back to the installed pump wrapper include-server path fix only.

The patch makes installed `pump` wrappers recover when the configured `include_server.py` path no longer exists but the include server is installed in the Python installation paths used by the configured Python interpreter.

## Related context

#392 - Reports the same installed `distcc-pump` failure mode: the wrapper points to an `include_server.py` path that does not exist, while the file is installed under a Python-versioned package path. This Pull Request addresses that path-resolution class.

#219 - Adjacent context, not fixed by this Pull Request. It reports pump include-server startup failures around `distcc_pump_c_extensions` import or discovery. That can look similar to users because pump fails before compilation starts, but this Pull Request only fixes locating `include_server.py`; it does not change C-extension discovery or loading.

## What This Actually Changes

Before this Pull Request, an installed `pump` wrapper could rely on one rewritten `include_server.py` path. If that path was stale or did not match the active Python install layout, pump startup failed before any distributed compile work could start.

After this change, `pump.in` still keeps the configured `include_server` path as the first choice. If that file is missing, it asks the configured Python interpreter for its `sysconfig` `purelib` and `platlib` paths and searches those locations for `include_server/include_server.py`.

The fallback is tied to the Python interpreter used by the wrapper. For example, a wrapper configured for Python 3.13 searches Python 3.13 install paths instead of guessing a generic directory.

## What this PR fixes

The failure pattern is:

```text
pump --startup
python: can't open file '.../include_server.py': No such file or directory
Could not start distcc-pump include server
```

The expected behavior after this change is:

```text
pump --startup
configured include_server path is missing
pump asks Python sysconfig for install paths
pump finds include_server/include_server.py under the installed Python path
pump starts the include server
```

This does not change the pump protocol, compression, remote compile behavior, or include scanning semantics. It fixes how the installed shell wrapper locates the Python include-server entry point.

## What changed in code

`pump.in` adds helper functions to query the configured Python interpreter for its major/minor version and `sysconfig` install paths. It writes candidate paths to a temporary file and reads them line-by-line so paths containing whitespace are not broken by shell word splitting.

`Makefile.in` adds `test/pump_include_server_path_test.py` to the test sources, makes `maintainer-check-no-set-path` depend on the generated `pump` script, and runs the new regression test after the existing `test/testdistcc.py` path succeeds.

`test/pump_include_server_path_test.py` builds a fake installed layout, intentionally sets the wrapper's recorded `include_server` path to a missing file, places fake include servers in the Python-derived candidate locations, and verifies that the wrapper can still run a command through pump startup and shutdown.

## Why this matters for users

Pump mode depends on the Python include server. If the installed wrapper cannot find `include_server.py`, users see pump fail immediately even though the package may contain the include server in a valid Python install location.

This is especially visible on distributions where Python package paths include a versioned directory such as `python3.13/site-packages`. The wrapper should follow the Python interpreter it was configured with instead of depending on one stale generated path.

For users, the practical result is that an installed `pump` or `distcc-pump` command has a better chance of starting correctly after installation or Python layout changes, without changing the rest of pump behavior.

## Scope boundaries

This Pull Request is limited to installed pump wrapper include-server path resolution and the regression test for that behavior.

Current branch scope is only:

```text
Makefile.in
pump.in
test/pump_include_server_path_test.py
```

It does not include Docker files, release workflows, RPM or Debian packaging files, container entrypoints, compression changes, Secure Shell changes, daemon option parsing, or unrelated test-harness changes.

## Validation

Passed locally:

```text
git diff --check origin/master...HEAD
python3.13 --version
python3.13 -m py_compile test/pump_include_server_path_test.py
sh -n pump.in
PYTHON=/usr/bin/python3.13 ./configure --enable-Werror
python3.13 test/pump_include_server_path_test.py ./pump /usr/bin/python3.13
make -j1 check_programs
local leak scan on the diff and Pull Request text
```

Additional local check:

```text
make -j1 distcc-maintainer-check
```

The `distcc-maintainer-check` command completed, but this local environment reported `NOTRUN` for Objective-C, Objective-C++, system include-directory, and system-specific assembly cases. I am not counting that as a fully green full-platform run under the strict local warning/skip policy.