### PR TITLE
distcc/ssh: Fix compiler warning about folding VLA

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -63,6 +63,8 @@
 #include "snprintf.h"
 #include "netutil.h"
 
+#define MAX_SSH_ARGS 12
+
 const char *dcc_default_ssh = "ssh";
 
 
@@ -193,9 +195,8 @@ int dcc_ssh_connect(char *ssh_cmd,
                     pid_t *ssh_pid)
 {
     pid_t ret;
-    const int max_ssh_args = 12;
-    char *ssh_args[max_ssh_args];
-    char *child_argv[11+max_ssh_args];
+    char *ssh_args[MAX_SSH_ARGS];
+    char *child_argv[11+MAX_SSH_ARGS];
     int i,j;
     int num_ssh_args = 0;
     char *ssh_cmd_in;
@@ -209,7 +210,7 @@ int dcc_ssh_connect(char *ssh_cmd,
         while (token != NULL) {
             ssh_args[num_ssh_args++] = token;
             token = strtok(NULL, " ");
-            if (num_ssh_args == max_ssh_args)
+            if (num_ssh_args == MAX_SSH_ARGS)
                 break;
         }
     }


### PR DESCRIPTION
Note that this came up recently in #595. I had independently come across the issue and fixed it a couple months ago but hadn't gotten around to upstreaming it.

----

This code was failing to compile on macOS 26 (clang 17.0.0) due to an error about folding a VLA into a constant array:

```
src/ssh.c:197:20: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
  197 |     char *ssh_args[max_ssh_args];
      |                    ^~~~~~~~~~~~
src/ssh.c:198:22: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
  198 |     char *child_argv[11+max_ssh_args];
      |                      ^~~~~~~~~~~~~~~
2 errors generated.
```

Discussed more in detail on Stack Overflow [1], the TLDR is the compiler views max_ssh_args as a variable (despite it being const) making ssh_args a VLA. Using a #define constant works around this (as does an enum, but #define is more "classic" C).

[1]: https://stackoverflow.com/questions/18435302/variable-length-array-folded-to-constant-array